### PR TITLE
Add conviva metadata for ad analytics

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaConnector.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaConnector.kt
@@ -64,6 +64,10 @@ class ConvivaConnector {
         videoAnalytics.setContentInfo(contentInfo)
     }
 
+    fun setAdInfo(adInfo: Map<String, Any>) {
+        adAnalytics.setAdInfo(adInfo)
+    }
+
     private fun setPlayerInfo() {
         val playerInfo = HashMap<String, Any>()
         playerInfo[ConvivaSdkConstants.FRAMEWORK_NAME] = "THEOplayer"


### PR DESCRIPTION
Align with web's conviva connector interface by allowing to add metadata for ad analytics. 