### PR TITLE
Feature/mediasession update

### DIFF
--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaMetadataProvider.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaMetadataProvider.kt
@@ -86,6 +86,9 @@ class MediaMetadataProvider(private val connector: MediaSessionConnector) {
             connector.mediaSession.setMetadata(METADATA_EMPTY)
             return
         }
+        if (sourceDescription.poster != null) {
+            builder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON_URI, sourceDescription.poster)
+        }
         val metadata = sourceDescription.metadata
         if (metadata != null) {
             buildString(metadata, builder, MediaMetadataCompat.METADATA_KEY_ALBUM)

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionCallback.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionCallback.kt
@@ -58,6 +58,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandlePlaybackAction(ACTION_PLAY)) {
             connector.player?.play()
+            connector.listeners.forEach { listener ->
+                listener.onPlay()
+            }
 
             // Make sure the session is currently active and ready to receive commands.
             connector.setActive(true)
@@ -70,6 +73,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandlePlaybackAction(ACTION_PAUSE)) {
             connector.player?.pause()
+            connector.listeners.forEach { listener ->
+                listener.onPause()
+            }
         }
     }
 
@@ -105,8 +111,11 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
             Log.d(TAG, "MediaSessionCallback::onStop")
         }
         if (shouldHandlePlaybackAction(ACTION_STOP)) {
-            connector.player?.stop()
-            connector.setActive(false)
+//            connector.player?.stop()
+//            connector.setActive(false)
+            connector.listeners.forEach { listener ->
+                listener.onStop()
+            }
         }
     }
 
@@ -225,6 +234,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandlePlaybackAction(ACTION_SEEK_TO)) {
             connector.player?.currentTime = 1e-03 * positionMs
+            connector.listeners.forEach { listener ->
+                listener.onSeekTo(positionMs)
+            }
         }
     }
 

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionCallback.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionCallback.kt
@@ -58,12 +58,12 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandlePlaybackAction(ACTION_PLAY)) {
             connector.player?.play()
-            connector.listeners.forEach { listener ->
-                listener.onPlay()
-            }
 
             // Make sure the session is currently active and ready to receive commands.
             connector.setActive(true)
+        }
+        connector.listeners.forEach { listener ->
+            listener.onPlay()
         }
     }
 
@@ -73,9 +73,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandlePlaybackAction(ACTION_PAUSE)) {
             connector.player?.pause()
-            connector.listeners.forEach { listener ->
-                listener.onPause()
-            }
+        }
+        connector.listeners.forEach { listener ->
+            listener.onPause()
         }
     }
 
@@ -111,11 +111,11 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
             Log.d(TAG, "MediaSessionCallback::onStop")
         }
         if (shouldHandlePlaybackAction(ACTION_STOP)) {
-//            connector.player?.stop()
-//            connector.setActive(false)
-            connector.listeners.forEach { listener ->
-                listener.onStop()
-            }
+            connector.player?.stop()
+            connector.setActive(false)
+        }
+        connector.listeners.forEach { listener ->
+            listener.onStop()
         }
     }
 
@@ -126,6 +126,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (shouldHandlePlaybackAction(ACTION_FAST_FORWARD)) {
             skip(DEFAULT_SKIP_TIME)
         }
+        connector.listeners.forEach { listener ->
+            listener.onFastForward()
+        }
     }
 
     override fun onRewind() {
@@ -134,6 +137,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandlePlaybackAction(ACTION_REWIND)) {
             skip(-DEFAULT_SKIP_TIME)
+        }
+        connector.listeners.forEach { listener ->
+            listener.onRewind()
         }
     }
 
@@ -158,6 +164,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (shouldHandlePlaybackAction(ACTION_SET_PLAYBACK_SPEED)) {
             connector.player?.playbackRate = speed.toDouble()
         }
+        connector.listeners.forEach { listener ->
+            listener.onSetPlaybackSpeed(speed)
+        }
     }
 
     override fun onSkipToNext() {
@@ -166,6 +175,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_NEXT)) {
             connector.queueNavigator?.onSkipToNext(connector.player!!)
+        }
+        connector.listeners.forEach { listener ->
+            listener.onSkipToNext()
         }
     }
 
@@ -176,6 +188,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_PREVIOUS)) {
             connector.queueNavigator?.onSkipToPrevious(connector.player!!)
         }
+        connector.listeners.forEach { listener ->
+            listener.onSkipToPrevious()
+        }
     }
 
     override fun onSkipToQueueItem(id: Long) {
@@ -184,6 +199,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_QUEUE_ITEM)) {
             connector.queueNavigator?.onSkipToQueueItem(connector.player!!, id)
+        }
+        connector.listeners.forEach { listener ->
+            listener.onSkipToQueueItem(id)
         }
     }
 
@@ -194,6 +212,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (shouldHandleQueueEditAction()) {
             connector.queueEditor?.onAddQueueItem(connector.player!!, description)
         }
+        connector.listeners.forEach { listener ->
+            listener.onAddQueueItem(description)
+        }
     }
 
     override fun onAddQueueItem(description: MediaDescriptionCompat, index: Int) {
@@ -202,6 +223,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandleQueueEditAction()) {
             connector.queueEditor?.onAddQueueItem(connector.player!!, description, index)
+        }
+        connector.listeners.forEach { listener ->
+            listener.onAddQueueItem(description)
         }
     }
 
@@ -212,18 +236,23 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (shouldHandleQueueEditAction()) {
             connector.queueEditor?.onRemoveQueueItem(connector.player!!, description)
         }
+        connector.listeners.forEach { listener ->
+            listener.onRemoveQueueItem(description)
+        }
     }
 
     override fun onCustomAction(action: String, extras: Bundle?) {
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onCustomAction $action")
         }
-        if (connector.player != null) {
-            val player = connector.player!!
+        connector.player?.let { player ->
             for (customActionProvider in connector.customActionProviders) {
                 if (customActionProvider.getCustomAction(player)?.action == action) {
                     customActionProvider.onCustomAction(player, action, extras)
                 }
+            }
+            connector.listeners.forEach { listener ->
+                listener.onCustomAction(action, extras)
             }
         }
     }
@@ -234,9 +263,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandlePlaybackAction(ACTION_SEEK_TO)) {
             connector.player?.currentTime = 1e-03 * positionMs
-            connector.listeners.forEach { listener ->
-                listener.onSeekTo(positionMs)
-            }
+        }
+        connector.listeners.forEach { listener ->
+            listener.onSeekTo(positionMs)
         }
     }
 
@@ -247,6 +276,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (shouldHandleRatingAction()) {
             connector.ratingCallback?.onSetRating(connector.player!!, rating)
         }
+        connector.listeners.forEach { listener ->
+            listener.onSetRating(rating, null)
+        }
     }
 
     override fun onSetRating(rating: RatingCompat, extras: Bundle?) {
@@ -255,6 +287,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         if (shouldHandleRatingAction()) {
             connector.ratingCallback?.onSetRating(connector.player!!, rating, extras)
+        }
+        connector.listeners.forEach { listener ->
+            listener.onSetRating(rating, extras)
         }
     }
 

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionCallback.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionCallback.kt
@@ -56,14 +56,16 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onPlay")
         }
-        if (shouldHandlePlaybackAction(ACTION_PLAY)) {
-            connector.player?.play()
+        connector.player?.let { player ->
+            if (shouldHandlePlaybackAction(ACTION_PLAY)) {
+                player.play()
 
-            // Make sure the session is currently active and ready to receive commands.
-            connector.setActive(true)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onPlay()
+                // Make sure the session is currently active and ready to receive commands.
+                connector.setActive(true)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onPlay()
+            }
         }
     }
 
@@ -71,11 +73,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onPause")
         }
-        if (shouldHandlePlaybackAction(ACTION_PAUSE)) {
-            connector.player?.pause()
-        }
-        connector.listeners.forEach { listener ->
-            listener.onPause()
+        connector.player?.let { player ->
+            if (shouldHandlePlaybackAction(ACTION_PAUSE)) {
+                player.pause()
+            }
+            connector.listeners.forEach { listener ->
+                listener.onPause()
+            }
         }
     }
 
@@ -110,12 +114,14 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onStop")
         }
-        if (shouldHandlePlaybackAction(ACTION_STOP)) {
-            connector.player?.stop()
-            connector.setActive(false)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onStop()
+        connector.player?.let { player ->
+            if (shouldHandlePlaybackAction(ACTION_STOP)) {
+                player.stop()
+                connector.setActive(false)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onStop()
+            }
         }
     }
 
@@ -161,11 +167,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onSetPlaybackSpeed $speed")
         }
-        if (shouldHandlePlaybackAction(ACTION_SET_PLAYBACK_SPEED)) {
-            connector.player?.playbackRate = speed.toDouble()
-        }
-        connector.listeners.forEach { listener ->
-            listener.onSetPlaybackSpeed(speed)
+        connector.player?.let { player ->
+            if (shouldHandlePlaybackAction(ACTION_SET_PLAYBACK_SPEED)) {
+                player.playbackRate = speed.toDouble()
+            }
+            connector.listeners.forEach { listener ->
+                listener.onSetPlaybackSpeed(speed)
+            }
         }
     }
 
@@ -173,11 +181,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onSkipToNext")
         }
-        if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_NEXT)) {
-            connector.queueNavigator?.onSkipToNext(connector.player!!)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onSkipToNext()
+        connector.player?.let { player ->
+            if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_NEXT)) {
+                connector.queueNavigator?.onSkipToNext(player)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onSkipToNext()
+            }
         }
     }
 
@@ -185,11 +195,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onSkipToPrevious")
         }
-        if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_PREVIOUS)) {
-            connector.queueNavigator?.onSkipToPrevious(connector.player!!)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onSkipToPrevious()
+        connector.player?.let { player ->
+            if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_PREVIOUS)) {
+                connector.queueNavigator?.onSkipToPrevious(player)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onSkipToPrevious()
+            }
         }
     }
 
@@ -197,11 +209,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onSkipToQueueItem")
         }
-        if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_QUEUE_ITEM)) {
-            connector.queueNavigator?.onSkipToQueueItem(connector.player!!, id)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onSkipToQueueItem(id)
+        connector.player?.let { player ->
+            if (shouldHandleQueueNavigatorAction(ACTION_SKIP_TO_QUEUE_ITEM)) {
+                connector.queueNavigator?.onSkipToQueueItem(player, id)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onSkipToQueueItem(id)
+            }
         }
     }
 
@@ -209,11 +223,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onAddQueueItem")
         }
-        if (shouldHandleQueueEditAction()) {
-            connector.queueEditor?.onAddQueueItem(connector.player!!, description)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onAddQueueItem(description)
+        connector.player?.let { player ->
+            if (shouldHandleQueueEditAction()) {
+                connector.queueEditor?.onAddQueueItem(player, description)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onAddQueueItem(description)
+            }
         }
     }
 
@@ -221,11 +237,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onAddQueueItem")
         }
-        if (shouldHandleQueueEditAction()) {
-            connector.queueEditor?.onAddQueueItem(connector.player!!, description, index)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onAddQueueItem(description)
+        connector.player?.let { player ->
+            if (shouldHandleQueueEditAction()) {
+                connector.queueEditor?.onAddQueueItem(player, description, index)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onAddQueueItem(description)
+            }
         }
     }
 
@@ -233,11 +251,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onRemoveQueueItem")
         }
-        if (shouldHandleQueueEditAction()) {
-            connector.queueEditor?.onRemoveQueueItem(connector.player!!, description)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onRemoveQueueItem(description)
+        connector.player?.let { player ->
+            if (shouldHandleQueueEditAction()) {
+                connector.queueEditor?.onRemoveQueueItem(player, description)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onRemoveQueueItem(description)
+            }
         }
     }
 
@@ -261,11 +281,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onSeekTo $positionMs")
         }
-        if (shouldHandlePlaybackAction(ACTION_SEEK_TO)) {
-            connector.player?.currentTime = 1e-03 * positionMs
-        }
-        connector.listeners.forEach { listener ->
-            listener.onSeekTo(positionMs)
+        connector.player?.let { player ->
+            if (shouldHandlePlaybackAction(ACTION_SEEK_TO)) {
+                player.currentTime = 1e-03 * positionMs
+            }
+            connector.listeners.forEach { listener ->
+                listener.onSeekTo(positionMs)
+            }
         }
     }
 
@@ -273,11 +295,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onSetRating $rating")
         }
-        if (shouldHandleRatingAction()) {
-            connector.ratingCallback?.onSetRating(connector.player!!, rating)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onSetRating(rating, null)
+        connector.player?.let { player ->
+            if (shouldHandleRatingAction()) {
+                connector.ratingCallback?.onSetRating(player, rating)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onSetRating(rating, null)
+            }
         }
     }
 
@@ -285,11 +309,13 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onSetRating $rating")
         }
-        if (shouldHandleRatingAction()) {
-            connector.ratingCallback?.onSetRating(connector.player!!, rating, extras)
-        }
-        connector.listeners.forEach { listener ->
-            listener.onSetRating(rating, extras)
+        connector.player?.let { player ->
+            if (shouldHandleRatingAction()) {
+                connector.ratingCallback?.onSetRating(player, rating, extras)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onSetRating(rating, extras)
+            }
         }
     }
 

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -46,6 +46,8 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
     private val metadataProvider: MediaMetadataProvider = MediaMetadataProvider(this)
     private val playbackStateProvider: PlaybackStateProvider = PlaybackStateProvider(this)
 
+    val listeners: MutableList<MediaSessionListener> = mutableListOf()
+
     var player: Player? = null
         set(value) {
             if (field != null) {
@@ -75,7 +77,7 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
     var shouldDispatchUnsupportedActions: Boolean = false
 
     /**
-     * Whether each timeupdate event should trigger an update in playback state.
+     * Whether each time update event should trigger an update in playback state.
      */
     var shouldDispatchTimeUpdateEvents: Boolean = false
 
@@ -128,11 +130,20 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
         }
     }
 
+    fun addListener(listener: MediaSessionListener) {
+        listeners.add(listener)
+    }
+
+    fun removeListener(listener: MediaSessionListener) {
+        listeners.remove(listener)
+    }
+
     /**
      * Release mediaSession.
      */
     fun destroy() {
         mediaSession.release()
+        listeners.clear()
         if (debug) {
             Log.d(TAG, "MediaSession released")
         }

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -65,9 +65,11 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
             } else {
                 metadataProvider.setMediaSessionMetadata(player?.source)
                 playbackStateProvider.updatePlaybackState(
-                    if (player?.isPaused == false) STATE_PLAYING
-                    else if (player?.isPaused == true) STATE_PAUSED
-                    else STATE_NONE
+                    when (player?.isPaused) {
+                        false -> STATE_PLAYING
+                        true -> STATE_PAUSED
+                        else -> STATE_NONE
+                    }
                 )
             }
         }

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -100,7 +100,6 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
     var customActionProviders: Array<CustomActionProvider> = arrayOf()
 
     init {
-        mediaSession.setCallback(mediaSessionCallback)
         if (debug) {
             Log.d(TAG, "Connector initialized")
         }

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -141,16 +141,28 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
         if (mediaSession.isActive == active) {
             return
         }
+
         mediaSession.isActive = active
+
+        // If mediaSession.isActive is `false`, mediaSession will still receive MediaSessionCallback
+        // events, so drop the callback when inactive.
+        mediaSession.setCallback(if (active) mediaSessionCallback else null)
+
         if (debug) {
             Log.d(TAG, "MediaSession setActive: $active")
         }
     }
 
+    /**
+     * Add a listener for media session callback actions.
+     */
     fun addListener(listener: MediaSessionListener) {
         listeners.add(listener)
     }
 
+    /**
+     * Remove a listener for media session callback actions.
+     */
     fun removeListener(listener: MediaSessionListener) {
         listeners.remove(listener)
     }

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -73,6 +73,12 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
         }
 
     var shouldDispatchUnsupportedActions: Boolean = false
+
+    /**
+     * Whether each timeupdate event should trigger an update in playback state.
+     */
+    var shouldDispatchTimeUpdateEvents: Boolean = false
+
     var debug: Boolean = BuildConfig.DEBUG
     var enabledPlaybackActions: Long = PlaybackStateProvider.DEFAULT_PLAYBACK_ACTIONS
     var customActionProviders: Array<CustomActionProvider> = arrayOf()

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package com.theoplayer.android.connector.mediasession
 
 import android.media.session.PlaybackState.*

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -1,6 +1,6 @@
 package com.theoplayer.android.connector.mediasession
 
-import android.media.session.PlaybackState.STATE_NONE
+import android.media.session.PlaybackState.*
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.util.Log
@@ -56,8 +56,17 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
             field = value
             playbackStateProvider.setPlayer(field)
 
-            metadataProvider.clearMediaSessionMetadataDescription()
-            playbackStateProvider.updatePlaybackState(STATE_NONE)
+            if (player?.source == null) {
+                metadataProvider.clearMediaSessionMetadataDescription()
+                playbackStateProvider.updatePlaybackState(STATE_NONE)
+            } else {
+                metadataProvider.setMediaSessionMetadata(player?.source)
+                playbackStateProvider.updatePlaybackState(
+                    if (player?.isPaused == false) STATE_PLAYING
+                    else if (player?.isPaused == true) STATE_PAUSED
+                    else STATE_NONE
+                )
+            }
         }
 
     var queueNavigator: QueueNavigator? = null

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -45,6 +45,7 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
     private val mediaSessionCallback: MediaSessionCallback = MediaSessionCallback(this)
     private val metadataProvider: MediaMetadataProvider = MediaMetadataProvider(this)
     private val playbackStateProvider: PlaybackStateProvider = PlaybackStateProvider(this)
+    private var destroyed = false
 
     val listeners: MutableList<MediaSessionListener> = mutableListOf()
 
@@ -96,6 +97,9 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
 
     init {
         mediaSession.setCallback(mediaSessionCallback)
+        if (debug) {
+            Log.d(TAG, "Connector initialized")
+        }
     }
 
     /**
@@ -151,6 +155,10 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
      * Release mediaSession.
      */
     fun destroy() {
+        if (destroyed) {
+            return
+        }
+        destroyed = true
         mediaSession.release()
         listeners.clear()
         if (debug) {

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionListener.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionListener.kt
@@ -1,0 +1,12 @@
+package com.theoplayer.android.connector.mediasession
+
+abstract class MediaSessionListener {
+
+    open fun onPlay() {}
+
+    open fun onPause() {}
+
+    open fun onStop() {}
+
+    open fun onSeekTo(positionMs: Long) {}
+}

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionListener.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionListener.kt
@@ -1,5 +1,9 @@
 package com.theoplayer.android.connector.mediasession
 
+import android.os.Bundle
+import android.support.v4.media.MediaDescriptionCompat
+import android.support.v4.media.RatingCompat
+
 abstract class MediaSessionListener {
 
     open fun onPlay() {}
@@ -9,4 +13,24 @@ abstract class MediaSessionListener {
     open fun onStop() {}
 
     open fun onSeekTo(positionMs: Long) {}
+
+    open fun onFastForward() {}
+
+    open fun onRewind() {}
+
+    open fun onSetPlaybackSpeed(speed: Float) {}
+
+    open fun onSkipToNext() {}
+
+    open fun onSkipToPrevious() {}
+
+    open fun onSkipToQueueItem(id: Long) {}
+
+    open fun onAddQueueItem(description: MediaDescriptionCompat) {}
+
+    open fun onRemoveQueueItem(description: MediaDescriptionCompat) {}
+
+    open fun onCustomAction(action: String, extras: Bundle?) {}
+
+    open fun onSetRating(rating: RatingCompat, extras: Bundle?) {}
 }

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionListener.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionListener.kt
@@ -3,6 +3,7 @@ package com.theoplayer.android.connector.mediasession
 import android.os.Bundle
 import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.RatingCompat
+import android.support.v4.media.session.MediaSessionCompat
 
 /**
  * MediaSessionListener provides the possibility to additionally listen to actions passed to the
@@ -10,31 +11,101 @@ import android.support.v4.media.RatingCompat
  */
 abstract class MediaSessionListener {
 
+    /**
+     * Called when media session requests to begin playback.
+     *
+     * @see MediaSessionCompat.Callback.onPlay
+     */
     open fun onPlay() {}
 
+    /**
+     * Called when media session requests to pause playback.
+     *
+     * @see MediaSessionCompat.Callback.onPause
+     */
     open fun onPause() {}
 
+    /**
+     * Called when media session requests to stop playback.
+     *
+     * @see MediaSessionCompat.Callback.onStop
+     */
     open fun onStop() {}
 
+    /**
+     * Called when media session requests to seek to a specific position in ms.
+     *
+     * @see MediaSessionCompat.Callback.onSeekTo
+     */
     open fun onSeekTo(positionMs: Long) {}
 
+    /**
+     * Called when media session requests to fast forward playback.
+     *
+     * @see MediaSessionCompat.Callback.onFastForward
+     */
     open fun onFastForward() {}
 
+    /**
+     * Called when media session requests to rewind playback.
+     *
+     * @see MediaSessionCompat.Callback.onRewind
+     */
     open fun onRewind() {}
 
+    /**
+     * Called when media session requests to change playback speed.
+     *
+     * @see MediaSessionCompat.Callback.onSetPlaybackSpeed
+     */
     open fun onSetPlaybackSpeed(speed: Float) {}
 
+    /**
+     * Called when media session requests to skip to the next item in the playback queue.
+     *
+     * @see MediaSessionCompat.Callback.onSkipToNext
+     */
     open fun onSkipToNext() {}
 
+    /**
+     * Called when media session requests to skip to the previous item in the playback queue.
+     *
+     * @see MediaSessionCompat.Callback.onSkipToPrevious
+     */
     open fun onSkipToPrevious() {}
 
+    /**
+     * Called when media session requests to skip to a specific queue item.
+     *
+     * @see MediaSessionCompat.Callback.onSkipToQueueItem
+     */
     open fun onSkipToQueueItem(id: Long) {}
 
+    /**
+     * Called when media session requests to add an item to the playback queue.
+     *
+     * @see MediaSessionCompat.Callback.onAddQueueItem
+     */
     open fun onAddQueueItem(description: MediaDescriptionCompat) {}
 
+    /**
+     * Called when media session requests to remove an item from the playback queue.
+     *
+     * @see MediaSessionCompat.Callback.onRemoveQueueItem
+     */
     open fun onRemoveQueueItem(description: MediaDescriptionCompat) {}
 
+    /**
+     * Called when media session requests to execute a custom action.
+     *
+     * @see MediaSessionCompat.Callback.onCustomAction
+     */
     open fun onCustomAction(action: String, extras: Bundle?) {}
 
+    /**
+     * Called when media session requests to se an item's rating.
+     *
+     * @see MediaSessionCompat.Callback.onSetRating
+     */
     open fun onSetRating(rating: RatingCompat, extras: Bundle?) {}
 }

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionListener.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionListener.kt
@@ -4,6 +4,10 @@ import android.os.Bundle
 import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.RatingCompat
 
+/**
+ * MediaSessionListener provides the possibility to additionally listen to actions passed to the
+ * player by MediaSessionCompat.Callback.
+ */
 abstract class MediaSessionListener {
 
     open fun onPlay() {}

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
@@ -72,7 +72,9 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
     }
 
     private val onTimeUpdate = { _: TimeUpdateEvent ->
-        invalidatePlaybackState()
+        if (connector.shouldDispatchTimeUpdateEvents) {
+            invalidatePlaybackState()
+        }
     }
 
     private val onSourceChange = { _: SourceChangeEvent ->


### PR DESCRIPTION
Add some additional features & fixes to the media session connector:

- The ability so disable invalidating the playback state on timeUpdate events; normally media session should interpolate the current time based on playback speed and other player properties;
- The ability to add a listener to MediaSessionCallback to listen in on any playback operations the media session request, and optionally add extra logic;
- the source description's poster property needs to have priority in the asset's metadata
- the player's playback state needs to be read at connector creation time, and applied (we can't assume the player starts paused)
- make sure the connector is released once, even when calling destroy multiple times.
- if the connector is set to `inActive`, do not listen for mediaSession callbacks. Even if the media session itself is set to `inActive`, it will still receive callbacks once registered.