### PR TITLE
Prevent crash in handle seeked event

### DIFF
--- a/connectors/analytics/comscore/src/main/java/com/theoplayer/android/connector/analytics/comscore/ComscoreAdapter.kt
+++ b/connectors/analytics/comscore/src/main/java/com/theoplayer/android/connector/analytics/comscore/ComscoreAdapter.kt
@@ -411,8 +411,8 @@ class ComscoreAdapter(
       Log.i(TAG, "DEBUG: SEEKED to: " + seekedEvent.currentTime)
     }
     val currentTime = seekedEvent.currentTime
-    if (isNaN(player.duration)) {
-      val seekableRanges = player.seekable
+    val seekableRanges = player.seekable
+    if (isNaN(player.duration) && seekableRanges.length() > 0) {
       val dvrWindowEnd = seekableRanges.getEnd(seekableRanges.length() - 1)
       val newDvrWindowOffset =
         java.lang.Double.valueOf(dvrWindowEnd - currentTime).toLong() * 1000


### PR DESCRIPTION
Prevent registering .startFromDvrWindowOffset event if seekalbe timeranges are empty