### PR TITLE
Skip building Yospace connector on JitPack

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,9 @@ pluginManagement {
     }
 }
 
+// https://jitpack.io/docs/BUILDING/#build-environment
+def isJitPack = System.getenv("JITPACK") == "true"
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -13,20 +16,27 @@ dependencyResolutionManagement {
         mavenCentral()
         maven { url 'https://maven.theoplayer.com/releases/' }
         maven { url 'https://raw.githubusercontent.com/NielsenDigitalSDK/nielsenappsdk-android/master/' }
-        maven {
-            url 'https://yospacerepo.jfrog.io/yospacerepo/android-sdk'
-            credentials {
-                username System.getenv("YOSPACE_USERNAME")
-                password System.getenv("YOSPACE_PASSWORD")
+        if (!isJitPack) {
+            // JitPack doesn't have credentials for the Yospace Maven repository.
+            maven {
+                url 'https://yospacerepo.jfrog.io/yospacerepo/android-sdk'
+                credentials {
+                    username System.getenv("YOSPACE_USERNAME")
+                    password System.getenv("YOSPACE_PASSWORD")
+                }
             }
         }
     }
 }
 
 rootProject.name = "THEOplayer Connector"
-include ':app'
 include ':connectors:analytics:comscore'
 include ':connectors:analytics:conviva'
 include ':connectors:analytics:nielsen'
 include ':connectors:mediasession'
-include ':connectors:yospace'
+
+if (!isJitPack) {
+    // JitPack can't build the Yospace connector.
+    include ':app'
+    include ':connectors:yospace'
+}


### PR DESCRIPTION
JitPack doesn't have the necessary credentials for the Yospace Maven repository, so it fails to build the project. From [the build log](https://jitpack.io/com/github/THEOplayer/android-connector/7.6.0/build.log):
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not resolve com.yospace:admanagement-sdk:3.6.7.
     Required by:
         project :app
      > Could not resolve com.yospace:admanagement-sdk:3.6.7.
         > Could not get resource 'https://yospacerepo.jfrog.io/yospacerepo/android-sdk/com/yospace/admanagement-sdk/3.6.7/admanagement-sdk-3.6.7.pom'.
            > Username must not be null!
```

Fix it by skipping the Yospace connector altogether on JitPack, so the other connectors can still be built and published. We will only publish the Yospace connector to [maven.theoplayer.com](https://maven.theoplayer.com/).