### PR TITLE
Bugfix/Conviva VST includes ad pre-roll duration

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -33,7 +33,6 @@ fun calculateCurrentAdBreakPosition(adBreak: AdBreak): String {
 
 fun calculateCurrentAdBreakInfo(adBreak: AdBreak, adBreakIndex: Int): Map<String, Any> {
     return mapOf(
-        ConvivaSdkConstants.POD_POSITION to calculateCurrentAdBreakPosition(adBreak),
         ConvivaSdkConstants.POD_DURATION to adBreak.maxDuration,
         ConvivaSdkConstants.POD_INDEX to adBreakIndex
     )

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,6 @@ mockitoKotlinVersion=4.1.0
 
 # NOTE: upgrading beyond 2.5.1 requires targetSdk 33
 lifecycleVersion=2.5.1
-convivaVersion=4.0.35
+convivaVersion=4.0.39
 comscoreVersion=6.10.0
 yospaceVersion=3.6.7


### PR DESCRIPTION
The VST (Video Startup Time) currently includes the duration of the pre-roll ad for VODs. This is due to the ConvivaSdkConstants.POD_POSITION parameter being passed when calling reportAdBreakStarted. As discussed with Conviva, this parameter should be removed.