### PR TITLE
Also force update if state was already PLAYING

### DIFF
--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
@@ -122,8 +122,10 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
         // Some clients listening to the mediaSession, such as Notifications, do not update the
         // currentTime until playbackState becomes PLAYING, so force it.
         val oldPlaybackState = playbackState
-        updatePlaybackState(PlaybackStateCompat.STATE_PLAYING)
-        updatePlaybackState(oldPlaybackState)
+        playbackState = PlaybackStateCompat.STATE_PLAYING
+        invalidatePlaybackState()
+        playbackState = oldPlaybackState
+        invalidatePlaybackState()
     }
 
     private val onDurationChange = { _: DurationChangeEvent ->


### PR DESCRIPTION
For mp3/mp4 assets, the player doesn't dispatch `progress` events, so we must force update here during state PLAYING as well. 
Note: MediaSession by default doesn't listen to timeupdates, it works out what the current time is by using the playback rate & progressed time.