### PR TITLE
Feature/conviva/error details

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -24,6 +24,7 @@ import com.theoplayer.android.connector.analytics.conviva.utils.calculateBufferL
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateConvivaOptions
 import com.theoplayer.android.connector.analytics.conviva.utils.collectContentMetadata
 import com.theoplayer.android.connector.analytics.conviva.utils.collectPlayerInfo
+import com.theoplayer.android.connector.analytics.conviva.utils.flattenErrorObject
 import java.lang.Double.isFinite
 
 private const val TAG = "ConvivaHandler"
@@ -138,9 +139,17 @@ class ConvivaHandler(
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "onError: ${event.errorObject.message}")
             }
+
+            val error = event.errorObject
+            // Optionally report error details, which should be a flat <String, String> map.
+            val errorDetails = flattenErrorObject(error)
+            if (errorDetails.isNotEmpty()) {
+                convivaVideoAnalytics.reportPlaybackEvent("ErrorDetailsEvent", errorDetails)
+            }
+
             // Report error and cleanup immediately.
             // The contentInfo provides metadata for the failed video.
-            reportPlaybackFailed(event.errorObject.message ?: "Fatal error occurred")
+            reportPlaybackFailed(error.message ?: "Fatal error occurred")
         }
 
         onSegmentNotFound = EventListener<SegmentNotFoundEvent> {

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -141,7 +141,7 @@ class ConvivaHandler(
             }
 
             val error = event.errorObject
-            // Optionally report error details, which should be a flat <String, String> map.
+            // Report error details in a separate event, which should be passed a flat <String, String> map.
             val errorDetails = flattenErrorObject(error)
             if (errorDetails.isNotEmpty()) {
                 convivaVideoAnalytics.reportPlaybackEvent("ErrorDetailsEvent", errorDetails)

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -4,6 +4,7 @@ import com.conviva.sdk.ConvivaSdkConstants
 import com.theoplayer.android.api.THEOplayerGlobal
 import com.theoplayer.android.api.ads.AdBreak
 import com.theoplayer.android.api.ads.GoogleImaAd
+import com.theoplayer.android.api.error.THEOplayerException
 import com.theoplayer.android.api.player.Player
 import com.theoplayer.android.connector.analytics.conviva.ConvivaConfiguration
 import com.theoplayer.android.connector.analytics.conviva.ConvivaMetadata
@@ -158,4 +159,13 @@ fun calculateBufferLength(player: Player): Long {
         }
     }
     return (1e3 * bufferLength).toLong()
+}
+
+fun flattenErrorObject(error: THEOplayerException): Map<String, String> {
+    return mapOf(
+        "code" to error.code.name,
+        "category" to error.category.name,
+        "stack" to (error.cause?.stackTraceToString() ?: ""),
+        "message" to (error.cause?.message ?: "")
+    ).filterValues { it != "" } // Remove entries with empty values
 }


### PR DESCRIPTION
Similar to the web connector, in case of an error we'll pass all known error details in a separate event. It will appear in Conviva as a custom event. This will help troubleshoot any errors that occur.