### PR TITLE
bugfix/conviva/preroll_islive

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
@@ -268,6 +268,7 @@ class AdReporter(
                 "c3.csid" to convivaVideoAnalytics.sessionId.toString(),
                 "contentAssetName" to contentAssetName,
                 "c3.ad.technology" to adTechnology,
+                ConvivaSdkConstants.IS_LIVE to false,
             )
             if (ad is GoogleImaAd) {
                 // Update with Google IMA specific information

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
@@ -13,12 +13,10 @@ import com.theoplayer.android.api.ads.ima.GoogleImaAdEventType
 import com.theoplayer.android.api.event.EventDispatcher
 import com.theoplayer.android.api.event.EventListener
 import com.theoplayer.android.api.event.ads.AdBeginEvent
-import com.theoplayer.android.api.event.ads.AdBreakBeginEvent
 import com.theoplayer.android.api.event.ads.AdBreakEndEvent
 import com.theoplayer.android.api.event.ads.AdEndEvent
 import com.theoplayer.android.api.event.ads.AdErrorEvent
 import com.theoplayer.android.api.event.ads.AdEvent
-import com.theoplayer.android.api.event.ads.AdIntegrationKind
 import com.theoplayer.android.api.event.ads.AdSkipEvent
 import com.theoplayer.android.api.event.ads.AdsEventTypes
 import com.theoplayer.android.api.event.player.*


### PR DESCRIPTION
Ads should not be reported with content type live.

When checking the ads section in Conviva's Pulse dashboard, the Content Category should never be "Live".