### PR TITLE
Pass all metadata to Conviva

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -171,6 +171,7 @@ class ConvivaHandler(
             }
             maybeReportPlaybackEnded()
             currentSource = player.source
+            customMetadata = mapOf()
         }
 
         onEnded = EventListener<EndedEvent> {
@@ -231,7 +232,7 @@ class ConvivaHandler(
             Log.d(TAG, "setContentInfo")
         }
         customMetadata = customMetadata + metadata
-        convivaVideoAnalytics.setContentInfo(this.customMetadata)
+        convivaVideoAnalytics.setContentInfo(customMetadata)
     }
 
     fun setAdInfo(metadata: ConvivaMetadata) {

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -231,7 +231,7 @@ class ConvivaHandler(
             Log.d(TAG, "setContentInfo")
         }
         customMetadata = customMetadata + metadata
-        convivaVideoAnalytics.setContentInfo(metadata)
+        convivaVideoAnalytics.setContentInfo(this.customMetadata)
     }
 
     fun setAdInfo(metadata: ConvivaMetadata) {


### PR DESCRIPTION
Applying the fix for the Web connector to Android: https://github.com/THEOplayer/web-connectors/pull/35/

This should fix an issue where custom tags are not passed to Conviva when the same source is replayed (without resetting the source).

An example to test with:
```kotlin
    private fun setSource(source: Source) {
        selectedSource = source
        theoplayerView.player.source = source.sourceDescription

        convivaConnector.setContentInfo(hashMapOf(
            "Conviva.assetName" to "THEO-Test",
            "customTag1" to "customValue1",
            "customTag2" to "customValue2"
        ))
    }
```

After `ended`, call `play()` on the player to replay the source and check the metadata on Touchstone.