### PR TITLE
Add consumer R8 file

### DIFF
--- a/connectors/analytics/comscore/consumer-rules.pro
+++ b/connectors/analytics/comscore/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.comscore.** { *; }
+-dontwarn com.comscore.**


### PR DESCRIPTION
Comscore throws an exception if it's being obfuscated. It would be better if it's in their own consumer-rules, but for now we have it in our connector.