### PR TITLE
revert connectorVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ tasks.dokkaHtmlMultiModule.configure {
 }
 
 subprojects {
-    version = connectorVersion
+    version = sdkVersion
 
     tasks.withType(AbstractDokkaLeafTask.class).configureEach {
         suppressObviousFunctions.set(true)

--- a/connectors/publish.gradle
+++ b/connectors/publish.gradle
@@ -42,7 +42,7 @@ afterEvaluate {
             release(MavenPublication) {
                 groupId project.ext.groupId
                 artifactId project.name
-                version project.ext.connectorVersion
+                version project.ext.sdkVersion
                 artifact(tasks.dokkaJavadocJar)
                 from components.release
             }

--- a/connectors/uplynk/build.gradle
+++ b/connectors/uplynk/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdk 21
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "LIBRARY_VERSION", "\"${connectorVersion}\"")
+        buildConfigField("String", "LIBRARY_VERSION", "\"${sdkVersion}\"")
     }
 
     buildTypes {

--- a/connectors/yospace/build.gradle
+++ b/connectors/yospace/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdk 21
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "LIBRARY_VERSION", "\"${connectorVersion}\"")
+        buildConfigField("String", "LIBRARY_VERSION", "\"${sdkVersion}\"")
     }
 
     buildTypes {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,3 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=true
 groupId=com.theoplayer.android-connector
 sdkVersion=8.11.0
-connectorVersion=8.11.1


### PR DESCRIPTION
I had to split the `sdkVersion` from `connectorVersion` since for 8.11.1 we only wanted to release the connectors - without the THEOplayer SDKs.
This will revert the changes so 8.12.0 can be released together with THEOplayer.