### PR TITLE
Feature/mediasession/clear metadata

### DIFF
--- a/app/src/main/java/com/theoplayer/android/connector/Sources.kt
+++ b/app/src/main/java/com/theoplayer/android/connector/Sources.kt
@@ -33,7 +33,7 @@ val sources: List<Source> by lazy {
                         .timeOffset("5")
                         .build()
                 )
-                .metadata(MetadataDescription(mapOf("title" to "BigBuckBunny with Google IMA ads")))
+                .metadata(MetadataDescription(mutableMapOf("title" to "BigBuckBunny with Google IMA ads")))
                 .build(),
             nielsenMetadata = hashMapOf(
                 "assetid" to "C112233",

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/CustomActionProvider.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/CustomActionProvider.kt
@@ -21,7 +21,7 @@ interface CustomActionProvider {
     /**
      * Get the custom action this provider can handle.
      *
-     * @param The THEOplayer instance currently attached to the connector.
+     * @param player The THEOplayer instance currently attached to the connector.
      * @return A [PlaybackStateCompat.CustomAction] instance.
      */
     fun getCustomAction(player: Player): PlaybackStateCompat.CustomAction?

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaMetadataProvider.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaMetadataProvider.kt
@@ -44,9 +44,8 @@ class MediaMetadataProvider(private val connector: MediaSessionConnector) {
      * Update metadata from [SourceDescription].
      */
     fun setMediaSessionMetadata(sourceDescription: SourceDescription?) {
-        clearMediaSessionMetadataDescription()
+        updateMetaDataDescription(sourceDescription)
         if (sourceDescription != null) {
-            updateMetaDataDescription(sourceDescription)
             invalidateMediaSessionMetadata()
         }
     }
@@ -76,7 +75,7 @@ class MediaMetadataProvider(private val connector: MediaSessionConnector) {
         }
         try {
             connector.mediaSession.setMetadata(getMediaSessionMetadata())
-        } catch(e: IllegalStateException) {
+        } catch (e: IllegalStateException) {
             Log.e(TAG, "Failed to set metadata: ${e.message}")
         }
     }
@@ -88,8 +87,7 @@ class MediaMetadataProvider(private val connector: MediaSessionConnector) {
         if (connector.debug) {
             Log.d(TAG, "MediaMetadataProvider::clearMediaSessionMetadataDescription")
         }
-        builder = MediaMetadataCompat.Builder()
-        connector.mediaSession.setMetadata(METADATA_EMPTY)
+        updateMetaDataDescription(null)
     }
 
     /**
@@ -308,6 +306,7 @@ class MediaMetadataProvider(private val connector: MediaSessionConnector) {
     }
 
     private fun updateMetaDataDescription(sourceDescription: SourceDescription?) {
+        builder = MediaMetadataCompat.Builder()
         if (sourceDescription == null) {
             connector.mediaSession.setMetadata(METADATA_EMPTY)
             return

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -194,6 +194,7 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
             return
         }
         destroyed = true
+        playbackStateProvider.destroy()
         mediaSession.release()
         listeners.clear()
         if (debug) {

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackPreparer.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackPreparer.kt
@@ -3,7 +3,6 @@ package com.theoplayer.android.connector.mediasession
 import android.net.Uri
 import android.os.Bundle
 import android.support.v4.media.session.PlaybackStateCompat
-import com.theoplayer.android.connector.mediasession.QueueNavigator.Companion.AVAILABLE_ACTIONS
 
 /**
  * PlaybackPreparer allows handling media prepare actions when sent by a media controller.

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
@@ -26,18 +26,6 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
     private var player: Player? = null
     private val builder = PlaybackStateCompat.Builder()
 
-    private val timeUpdateListener = EventListener<TimeUpdateEvent> { e -> onTimeUpdate(e) }
-    private val sourceChangeListener = EventListener<SourceChangeEvent> { e -> onSourceChange(e) }
-    private val loadedMetadataListener = EventListener<LoadedMetadataEvent> { e -> onLoadedMetadata(e) }
-    private val playListener = EventListener<PlayEvent> { e -> onPlay(e) }
-    private val playingListener = EventListener<PlayingEvent> { e -> onPlaying(e) }
-    private val pauseListener = EventListener<PauseEvent> { e -> onPause(e) }
-    private val errorListener = EventListener<ErrorEvent> { e -> onError(e) }
-    private val waitingListener = EventListener<WaitingEvent> { e -> onWaiting(e) }
-    private val endedListener = EventListener<EndedEvent> { e -> onEnded(e) }
-    private val seekedListener = EventListener<SeekedEvent> { e -> onSeeked(e) }
-    private val durationChangeListener = EventListener<DurationChangeEvent> { e -> onDurationChange(e) }
-
     @PlaybackStateCompat.State
     private var playbackState = PlaybackStateCompat.STATE_NONE
 
@@ -56,43 +44,43 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
 
     private fun registerListeners() {
         player?.apply {
-            addEventListener(PlayerEventTypes.TIMEUPDATE, timeUpdateListener)
-            addEventListener(PlayerEventTypes.SOURCECHANGE, sourceChangeListener)
-            addEventListener(PlayerEventTypes.LOADEDMETADATA, loadedMetadataListener)
-            addEventListener(PlayerEventTypes.PLAY, playListener)
-            addEventListener(PlayerEventTypes.PLAYING, playingListener)
-            addEventListener(PlayerEventTypes.PAUSE, pauseListener)
-            addEventListener(PlayerEventTypes.ERROR, errorListener)
-            addEventListener(PlayerEventTypes.WAITING, waitingListener)
-            addEventListener(PlayerEventTypes.ENDED, endedListener)
-            addEventListener(PlayerEventTypes.SEEKED, seekedListener)
-            addEventListener(PlayerEventTypes.DURATIONCHANGE, durationChangeListener)
+            addEventListener(PlayerEventTypes.TIMEUPDATE, onTimeUpdate)
+            addEventListener(PlayerEventTypes.SOURCECHANGE, onSourceChange)
+            addEventListener(PlayerEventTypes.LOADEDMETADATA, onLoadedMetadata)
+            addEventListener(PlayerEventTypes.PLAY, onPlay)
+            addEventListener(PlayerEventTypes.PLAYING, onPlaying)
+            addEventListener(PlayerEventTypes.PAUSE, onPause)
+            addEventListener(PlayerEventTypes.ERROR, onError)
+            addEventListener(PlayerEventTypes.WAITING, onWaiting)
+            addEventListener(PlayerEventTypes.ENDED, onEnded)
+            addEventListener(PlayerEventTypes.SEEKED, onSeeked)
+            addEventListener(PlayerEventTypes.DURATIONCHANGE, onDurationChange)
         }
     }
 
     private fun unregisterListeners() {
         player?.apply {
-            removeEventListener(PlayerEventTypes.TIMEUPDATE, timeUpdateListener)
-            removeEventListener(PlayerEventTypes.SOURCECHANGE, sourceChangeListener)
-            removeEventListener(PlayerEventTypes.LOADEDMETADATA, loadedMetadataListener)
-            removeEventListener(PlayerEventTypes.PLAY, playListener)
-            removeEventListener(PlayerEventTypes.PLAYING, playingListener)
-            removeEventListener(PlayerEventTypes.PAUSE, pauseListener)
-            removeEventListener(PlayerEventTypes.ERROR, errorListener)
-            removeEventListener(PlayerEventTypes.WAITING, waitingListener)
-            removeEventListener(PlayerEventTypes.ENDED, endedListener)
-            removeEventListener(PlayerEventTypes.SEEKED, seekedListener)
-            removeEventListener(PlayerEventTypes.DURATIONCHANGE, durationChangeListener)
+            removeEventListener(PlayerEventTypes.TIMEUPDATE, onTimeUpdate)
+            removeEventListener(PlayerEventTypes.SOURCECHANGE, onSourceChange)
+            removeEventListener(PlayerEventTypes.LOADEDMETADATA, onLoadedMetadata)
+            removeEventListener(PlayerEventTypes.PLAY, onPlay)
+            removeEventListener(PlayerEventTypes.PLAYING, onPlaying)
+            removeEventListener(PlayerEventTypes.PAUSE, onPause)
+            removeEventListener(PlayerEventTypes.ERROR, onError)
+            removeEventListener(PlayerEventTypes.WAITING, onWaiting)
+            removeEventListener(PlayerEventTypes.ENDED, onEnded)
+            removeEventListener(PlayerEventTypes.SEEKED, onSeeked)
+            removeEventListener(PlayerEventTypes.DURATIONCHANGE, onDurationChange)
         }
     }
 
-    private val onTimeUpdate = { _: TimeUpdateEvent ->
+    private val onTimeUpdate = EventListener<TimeUpdateEvent> { _ ->
         if (connector.shouldDispatchTimeUpdateEvents) {
             invalidatePlaybackState()
         }
     }
 
-    private val onSourceChange = { _: SourceChangeEvent ->
+    private val onSourceChange = EventListener<SourceChangeEvent> { _ ->
         if (player?.source != null) {
             updatePlaybackState(PlaybackStateCompat.STATE_PAUSED)
         } else {
@@ -101,37 +89,37 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
         connector.setMediaSessionMetadata(player?.source)
     }
 
-    private val onLoadedMetadata = { _: LoadedMetadataEvent ->
+    private val onLoadedMetadata = EventListener<LoadedMetadataEvent> { _ ->
         connector.invalidateMediaSessionMetadata()
     }
 
-    private val onPlay = { _: PlayEvent ->
+    private val onPlay = EventListener<PlayEvent> { _ ->
         if (player!!.readyState.ordinal < ReadyState.HAVE_CURRENT_DATA.ordinal) {
             updatePlaybackState(PlaybackStateCompat.STATE_BUFFERING)
         }
     }
 
-    private val onPlaying = { _: PlayingEvent ->
+    private val onPlaying = EventListener<PlayingEvent> { _ ->
         updatePlaybackState(PlaybackStateCompat.STATE_PLAYING)
     }
 
-    private val onPause = { _: PauseEvent ->
+    private val onPause = EventListener<PauseEvent> { _ ->
         updatePlaybackState(PlaybackStateCompat.STATE_PAUSED)
     }
 
-    private val onError = { _: ErrorEvent ->
+    private val onError = EventListener<ErrorEvent> { _ ->
         updatePlaybackState(PlaybackStateCompat.STATE_ERROR)
     }
 
-    private val onWaiting = { _: WaitingEvent ->
+    private val onWaiting = EventListener<WaitingEvent> { _ ->
         updatePlaybackState(PlaybackStateCompat.STATE_BUFFERING)
     }
 
-    private val onEnded = { _: EndedEvent ->
+    private val onEnded = EventListener<EndedEvent> { _ ->
         updatePlaybackState(PlaybackStateCompat.STATE_PAUSED)
     }
 
-    private val onSeeked = { _: SeekedEvent ->
+    private val onSeeked = EventListener<SeekedEvent> { _ ->
         // Some clients listening to the mediaSession, such as Notifications, do not update the
         // currentTime until playbackState becomes PLAYING, so force it.
         val oldPlaybackState = playbackState
@@ -141,7 +129,7 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
         invalidatePlaybackState()
     }
 
-    private val onDurationChange = { _: DurationChangeEvent ->
+    private val onDurationChange = EventListener<DurationChangeEvent> { _ ->
         connector.invalidateMediaSessionMetadata()
     }
 

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
@@ -5,6 +5,7 @@ import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import android.text.TextUtils
 import android.util.Log
+import com.theoplayer.android.api.event.EventListener
 import com.theoplayer.android.api.event.player.*
 import com.theoplayer.android.api.player.Player
 import com.theoplayer.android.api.player.ReadyState
@@ -25,6 +26,18 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
     private var player: Player? = null
     private val builder = PlaybackStateCompat.Builder()
 
+    private val timeUpdateListener = EventListener<TimeUpdateEvent> { e -> onTimeUpdate(e) }
+    private val sourceChangeListener = EventListener<SourceChangeEvent> { e -> onSourceChange(e) }
+    private val loadedMetadataListener = EventListener<LoadedMetadataEvent> { e -> onLoadedMetadata(e) }
+    private val playListener = EventListener<PlayEvent> { e -> onPlay(e) }
+    private val playingListener = EventListener<PlayingEvent> { e -> onPlaying(e) }
+    private val pauseListener = EventListener<PauseEvent> { e -> onPause(e) }
+    private val errorListener = EventListener<ErrorEvent> { e -> onError(e) }
+    private val waitingListener = EventListener<WaitingEvent> { e -> onWaiting(e) }
+    private val endedListener = EventListener<EndedEvent> { e -> onEnded(e) }
+    private val seekedListener = EventListener<SeekedEvent> { e -> onSeeked(e) }
+    private val durationChangeListener = EventListener<DurationChangeEvent> { e -> onDurationChange(e) }
+
     @PlaybackStateCompat.State
     private var playbackState = PlaybackStateCompat.STATE_NONE
 
@@ -43,33 +56,33 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
 
     private fun registerListeners() {
         player?.apply {
-            addEventListener(PlayerEventTypes.TIMEUPDATE, onTimeUpdate)
-            addEventListener(PlayerEventTypes.SOURCECHANGE, onSourceChange)
-            addEventListener(PlayerEventTypes.LOADEDMETADATA, onLoadedMetadata)
-            addEventListener(PlayerEventTypes.PLAY, onPlay)
-            addEventListener(PlayerEventTypes.PLAYING, onPlaying)
-            addEventListener(PlayerEventTypes.PAUSE, onPause)
-            addEventListener(PlayerEventTypes.ERROR, onError)
-            addEventListener(PlayerEventTypes.WAITING, onWaiting)
-            addEventListener(PlayerEventTypes.ENDED, onEnded)
-            addEventListener(PlayerEventTypes.SEEKED, onSeeked)
-            addEventListener(PlayerEventTypes.DURATIONCHANGE, onDurationChange)
+            addEventListener(PlayerEventTypes.TIMEUPDATE, timeUpdateListener)
+            addEventListener(PlayerEventTypes.SOURCECHANGE, sourceChangeListener)
+            addEventListener(PlayerEventTypes.LOADEDMETADATA, loadedMetadataListener)
+            addEventListener(PlayerEventTypes.PLAY, playListener)
+            addEventListener(PlayerEventTypes.PLAYING, playingListener)
+            addEventListener(PlayerEventTypes.PAUSE, pauseListener)
+            addEventListener(PlayerEventTypes.ERROR, errorListener)
+            addEventListener(PlayerEventTypes.WAITING, waitingListener)
+            addEventListener(PlayerEventTypes.ENDED, endedListener)
+            addEventListener(PlayerEventTypes.SEEKED, seekedListener)
+            addEventListener(PlayerEventTypes.DURATIONCHANGE, durationChangeListener)
         }
     }
 
     private fun unregisterListeners() {
         player?.apply {
-            removeEventListener(PlayerEventTypes.TIMEUPDATE, onTimeUpdate)
-            removeEventListener(PlayerEventTypes.SOURCECHANGE, onSourceChange)
-            removeEventListener(PlayerEventTypes.LOADEDMETADATA, onLoadedMetadata)
-            removeEventListener(PlayerEventTypes.PLAY, onPlay)
-            removeEventListener(PlayerEventTypes.PLAYING, onPlaying)
-            removeEventListener(PlayerEventTypes.PAUSE, onPause)
-            removeEventListener(PlayerEventTypes.ERROR, onError)
-            removeEventListener(PlayerEventTypes.WAITING, onWaiting)
-            removeEventListener(PlayerEventTypes.ENDED, onEnded)
-            removeEventListener(PlayerEventTypes.SEEKED, onSeeked)
-            removeEventListener(PlayerEventTypes.DURATIONCHANGE, onDurationChange)
+            removeEventListener(PlayerEventTypes.TIMEUPDATE, timeUpdateListener)
+            removeEventListener(PlayerEventTypes.SOURCECHANGE, sourceChangeListener)
+            removeEventListener(PlayerEventTypes.LOADEDMETADATA, loadedMetadataListener)
+            removeEventListener(PlayerEventTypes.PLAY, playListener)
+            removeEventListener(PlayerEventTypes.PLAYING, playingListener)
+            removeEventListener(PlayerEventTypes.PAUSE, pauseListener)
+            removeEventListener(PlayerEventTypes.ERROR, errorListener)
+            removeEventListener(PlayerEventTypes.WAITING, waitingListener)
+            removeEventListener(PlayerEventTypes.ENDED, endedListener)
+            removeEventListener(PlayerEventTypes.SEEKED, seekedListener)
+            removeEventListener(PlayerEventTypes.DURATIONCHANGE, durationChangeListener)
         }
     }
 


### PR DESCRIPTION
Several fixes to the MediaSession connector:

- Listeners were not properly removed from the PlaybackStateProvider on connector destruction;
- When passing a new source, setting an explicit empty metadata to the mediasession made that Android Auto apps returned to the queue overview after switching to another asset using the skip next/prev buttons.