### PR TITLE
Bugfix/islive override

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -415,9 +415,7 @@ class ConvivaHandler(
             // "play" for the first time, to accurately attribute metadata to the video asset.
             reportMetadata()
 
-            convivaVideoAnalytics.reportPlaybackRequested(
-                collectContentMetadata(player, convivaMetadata)
-            )
+            convivaVideoAnalytics.reportPlaybackRequested(convivaMetadata)
         }
     }
 

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -25,9 +25,8 @@ import com.theoplayer.android.connector.analytics.conviva.utils.ErrorReportBuild
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateBufferLength
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateConvivaOptions
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateStreamType
-import com.theoplayer.android.connector.analytics.conviva.utils.collectContentMetadata
+import com.theoplayer.android.connector.analytics.conviva.utils.collectPlaybackConfigMetadata
 import com.theoplayer.android.connector.analytics.conviva.utils.collectPlayerInfo
-import java.lang.Double.isFinite
 
 private const val TAG = "ConvivaHandler"
 
@@ -459,6 +458,8 @@ class ConvivaHandler(
                 ConvivaSdkConstants.ASSET_NAME to contentAssetName,
                 ConvivaSdkConstants.PLAYER_NAME to playerName
             ).apply {
+                putAll(collectPlaybackConfigMetadata(player))
+
                 // Do not override the `isLive` value if already set by the consumer, as the value
                 // is read-only for a given session.
                 if (!convivaVideoAnalytics.metadataInfo.containsKey(ConvivaSdkConstants.IS_LIVE)) {

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -466,12 +466,15 @@ class ConvivaHandler(
 
                 // Do not override the `isLive` value if already set by the consumer, as the value
                 // is read-only for a given session.
-                if (!convivaVideoAnalytics.metadataInfo.containsKey(ConvivaSdkConstants.IS_LIVE)) {
-                    // Only pass `isLive` property if we have a valid duration
-                    calculateStreamType(player)?.let { isLive ->
-                        put(ConvivaSdkConstants.IS_LIVE, isLive)
-                    }
+                // Note: also allow "Conviva.streamType" as metadata key, which is used on other platforms.
+                val configuredStreamType = convivaVideoAnalytics.metadataInfo[ConvivaSdkConstants.IS_LIVE] ?:
+                        convivaVideoAnalytics.metadataInfo["Conviva.streamType"]
+                // Only pass `isLive` property if pre-configured, or if we have a valid duration
+                val isLive = configuredStreamType ?: calculateStreamType(player)
+                isLive?.let {
+                    put(ConvivaSdkConstants.IS_LIVE, it)
                 }
+
                 // Only pass a finite duration value, never NaN or Infinite.
                 if (player.duration.isFinite()) {
                     // Report duration; Int (seconds)

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -197,20 +197,7 @@ class ConvivaHandler(
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "onDurationChange")
             }
-            val contentInfo = HashMap<String, Any>()
-            // Do not override the `isLive` value if already set by the consumer, as the value
-            // is read-only for a given session.
-            if (!convivaVideoAnalytics.metadataInfo.containsKey(ConvivaSdkConstants.IS_LIVE)) {
-                calculateStreamType(player)?.let { isLive ->
-                    contentInfo[ConvivaSdkConstants.IS_LIVE] = isLive
-                }
-            }
-            // Only pass a finite duration value, never NaN or Infinite.
-            if (player.duration.isFinite()) {
-                // Report duration; Int (seconds)
-                contentInfo[ConvivaSdkConstants.DURATION] = player.duration.toInt()
-            }
-            convivaVideoAnalytics.setContentInfo(contentInfo)
+            reportMetadata()
         }
 
         // Listen for player events
@@ -479,8 +466,13 @@ class ConvivaHandler(
                 if (!convivaVideoAnalytics.metadataInfo.containsKey(ConvivaSdkConstants.IS_LIVE)) {
                     // Only pass `isLive` property if we have a valid duration
                     calculateStreamType(player)?.let { isLive ->
-                        this.put(ConvivaSdkConstants.IS_LIVE, isLive)
+                        put(ConvivaSdkConstants.IS_LIVE, isLive)
                     }
+                }
+                // Only pass a finite duration value, never NaN or Infinite.
+                if (player.duration.isFinite()) {
+                    // Report duration; Int (seconds)
+                    put(ConvivaSdkConstants.DURATION, player.duration.toInt())
                 }
             }
         )

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -447,6 +447,10 @@ class ConvivaHandler(
             }
         }
 
+    /**
+     * Report extra metadata extracted from the player, next to the custom metadata provided by the
+     * customer.
+     */
     private fun reportMetadata() {
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "reportMetadata")

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -198,8 +198,12 @@ class ConvivaHandler(
                 Log.d(TAG, "onDurationChange")
             }
             val contentInfo = HashMap<String, Any>()
-            calculateStreamType(player)?.let { isLive ->
-                contentInfo[ConvivaSdkConstants.IS_LIVE] = isLive
+            // Do not override the `isLive` value if already set by the consumer, as the value
+            // is read-only for a given session.
+            if (!convivaVideoAnalytics.metadataInfo.containsKey(ConvivaSdkConstants.IS_LIVE)) {
+                calculateStreamType(player)?.let { isLive ->
+                    contentInfo[ConvivaSdkConstants.IS_LIVE] = isLive
+                }
             }
             // Only pass a finite duration value, never NaN or Infinite.
             if (player.duration.isFinite()) {
@@ -470,9 +474,13 @@ class ConvivaHandler(
                 ConvivaSdkConstants.ASSET_NAME to contentAssetName,
                 ConvivaSdkConstants.PLAYER_NAME to playerName
             ).apply {
-                // Only pass `isLive` property if we have a valid duration
-                calculateStreamType(player)?.let { isLive ->
-                    this.put(ConvivaSdkConstants.IS_LIVE, isLive)
+                // Do not override the `isLive` value if already set by the consumer, as the value
+                // is read-only for a given session.
+                if (!convivaVideoAnalytics.metadataInfo.containsKey(ConvivaSdkConstants.IS_LIVE)) {
+                    // Only pass `isLive` property if we have a valid duration
+                    calculateStreamType(player)?.let { isLive ->
+                        this.put(ConvivaSdkConstants.IS_LIVE, isLive)
+                    }
                 }
             }
         )

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -91,16 +91,18 @@ fun collectPlayerInfo(): Map<String, Any> {
     )
 }
 
-fun collectContentMetadata(
-    player: Player,
-    configuredContentMetadata: ConvivaMetadata
-): ConvivaMetadata {
-    // Never send an Infinity or NaN
-    val duration = player.duration
-    return if (duration.isNaN() || duration.isInfinite())
-        configuredContentMetadata
-    else
-        configuredContentMetadata + mapOf(ConvivaSdkConstants.DURATION to duration.toInt())
+fun collectPlaybackConfigMetadata(player: Player): ConvivaMetadata {
+    return mutableMapOf<String, Any>(
+        "targetBuffer" to player.abr.targetBuffer,
+        "abrStrategy" to player.abr.abrStrategy.type,
+    ).apply {
+        player.abr.abrStrategy.metadata?.bitrate?.let { abrMetadata ->
+            put("abrMetadata", abrMetadata)
+        }
+        player.source?.sources?.firstOrNull()?.liveOffset?.let { liveOffset ->
+            put("liveOffset", liveOffset)
+        }
+    }
 }
 
 private fun validStringOrNA(str: String?): String {

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -94,7 +94,7 @@ fun collectPlayerInfo(): Map<String, Any> {
 fun collectPlaybackConfigMetadata(player: Player): ConvivaMetadata {
     return mutableMapOf<String, Any>(
         "targetBuffer" to player.abr.targetBuffer,
-        "abrStrategy" to player.abr.abrStrategy.type,
+        "abrStrategy" to player.abr.abrStrategy.type.name.lowercase(),
     ).apply {
         player.abr.abrStrategy.metadata?.bitrate?.let { abrMetadata ->
             put("abrMetadata", abrMetadata)

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -1,6 +1,7 @@
 package com.theoplayer.android.connector.analytics.conviva.utils
 
 import com.conviva.sdk.ConvivaSdkConstants
+import com.conviva.sdk.ConvivaSdkConstants.StreamType
 import com.theoplayer.android.api.THEOplayerGlobal
 import com.theoplayer.android.api.ads.AdBreak
 import com.theoplayer.android.api.ads.Ad
@@ -11,6 +12,7 @@ import com.theoplayer.android.api.player.Player
 import com.theoplayer.android.api.timerange.TimeRanges
 import com.theoplayer.android.connector.analytics.conviva.ConvivaConfiguration
 import com.theoplayer.android.connector.analytics.conviva.ConvivaMetadata
+import java.lang.Double.isFinite
 
 fun calculateAdType(ad: Ad): ConvivaSdkConstants.AdType {
     return when(ad.integration) {
@@ -68,6 +70,18 @@ fun calculateConvivaOptions(config: ConvivaConfiguration): Map<String, Any> {
         options[ConvivaSdkConstants.GATEWAY_URL] = config.gatewayUrl
     }
     return options
+}
+
+fun calculateStreamType(player: Player): StreamType? {
+    return if (!player.duration.isNaN()) {
+        if (isFinite(player.duration)) {
+            StreamType.VOD
+        } else {
+            StreamType.LIVE
+        }
+    } else {
+        null
+    }
 }
 
 fun collectPlayerInfo(): Map<String, Any> {


### PR DESCRIPTION
- Simplify/restructure metadata passing
- Don't override the Conviva.streamType tag if it was already set by the customer through the API: the value is read-only in the back-end and can cause issues if it is set again with a different value.
- Pass extra stream config values as custom metadata: `liveOffset`, `targetBuffer`, `abrStrategy` and `abrMetadata`.

Note that other platforms (Web) use 'Conviva.streamType' as metadata key to pass the isLive value - either VOD or LIVE. The connector internally translates to 'Conviva.isLive'.

This PR applies the same changes as [this PR](https://github.com/THEOplayer/web-connectors/pull/83) on the web connector.