### PR TITLE
BugFix/Conviva not reporting metadata and contentType starting from 9.4.0 on VSF

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -179,6 +179,8 @@ class ConvivaHandler(
                     else -> "NA"
                 }
             )
+            // Set the metadata we have right now. It can be further updated before the `play` event
+            reportMetadata()
         }
 
         onEnded = EventListener<EndedEvent> {
@@ -454,11 +456,14 @@ class ConvivaHandler(
             Log.d(TAG, "reportMetadata")
         }
         val playerName = customMetadata[ConvivaSdkConstants.PLAYER_NAME] ?: convivaMetadata[ConvivaSdkConstants.PLAYER_NAME] ?: "THEOplayer"
+        val viewerId = customMetadata[ConvivaSdkConstants.VIEWER_ID] ?: convivaMetadata[ConvivaSdkConstants.VIEWER_ID] ?: "viewerId"
+
         setContentInfo(
             mutableMapOf(
                 ConvivaSdkConstants.STREAM_URL to (player.src ?: ""),
                 ConvivaSdkConstants.ASSET_NAME to contentAssetName,
-                ConvivaSdkConstants.PLAYER_NAME to playerName
+                ConvivaSdkConstants.PLAYER_NAME to playerName,
+                ConvivaSdkConstants.VIEWER_ID to viewerId
             ).apply {
                 putAll(collectPlaybackConfigMetadata(player))
 


### PR DESCRIPTION
In TheoPlayer 9.4.0 the `play` event is fired only when the tracks are successfully loaded. If the stream URL is invalid, then the `PlayEvent` is not fired. The Conviva connector was setting the metadata on receiving the `PlayEvent`. In case of error the `PlayEvent` is not fired, the metadata is not set when the `ErrorEvent` was fired. To fix the issue update the metadata in `SourceChangeEvent`. Conviva SDK maintains the metadata and merges it internally when new metadata is set, so it can be updated multiple times without any side-effects.