### PR TITLE
Improve passing correct duration for THEOads

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -138,7 +138,7 @@ fun updateAdMetadataForGoogleIma(ad: GoogleImaAd, metadata: ConvivaMetadata): Co
 fun collectAdMetadata(ad: Ad): ConvivaMetadata {
     // AssetName should never be an empty string
     return mutableMapOf(
-        ConvivaSdkConstants.DURATION to if (ad is LinearAd) ad.duration else 0,
+        ConvivaSdkConstants.DURATION to if (ad is LinearAd) ad.durationAsDouble else 0.0,
         ConvivaSdkConstants.ASSET_NAME to ad.id,
 
         // [Required] This Ad ID is from the Ad Server that actually has the ad creative.

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -138,7 +138,7 @@ fun updateAdMetadataForGoogleIma(ad: GoogleImaAd, metadata: ConvivaMetadata): Co
 fun collectAdMetadata(ad: Ad): ConvivaMetadata {
     // AssetName should never be an empty string
     return mutableMapOf(
-        ConvivaSdkConstants.DURATION to (ad as? LinearAd)?.durationAsDouble ?? 0.0,
+        ConvivaSdkConstants.DURATION to ((ad as? LinearAd)?.durationAsDouble ?: 0.0),
         ConvivaSdkConstants.ASSET_NAME to ad.id,
 
         // [Required] This Ad ID is from the Ad Server that actually has the ad creative.

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -138,7 +138,7 @@ fun updateAdMetadataForGoogleIma(ad: GoogleImaAd, metadata: ConvivaMetadata): Co
 fun collectAdMetadata(ad: Ad): ConvivaMetadata {
     // AssetName should never be an empty string
     return mutableMapOf(
-        ConvivaSdkConstants.DURATION to if (ad is LinearAd) ad.durationAsDouble else 0.0,
+        ConvivaSdkConstants.DURATION to (ad as? LinearAd)?.durationAsDouble ?? 0.0,
         ConvivaSdkConstants.ASSET_NAME to ad.id,
 
         // [Required] This Ad ID is from the Ad Server that actually has the ad creative.


### PR DESCRIPTION
We currently pass duration as an integer. This PR improves this to use the Player API to get the duration as a double.
Remark : This player API will become available once 9.7 will be out!