### PR TITLE
Report THEOlive events to Conviva

### DIFF
--- a/app/src/main/java/com/theoplayer/android/connector/Sources.kt
+++ b/app/src/main/java/com/theoplayer/android/connector/Sources.kt
@@ -7,6 +7,7 @@ import com.theoplayer.android.api.source.SourceType
 import com.theoplayer.android.api.source.TypedSource
 import com.theoplayer.android.api.source.addescription.GoogleImaAdDescription
 import com.theoplayer.android.api.source.metadata.MetadataDescription
+import com.theoplayer.android.api.theolive.TheoLiveSource
 import com.theoplayer.android.connector.uplynk.UplynkAssetType
 import com.theoplayer.android.connector.uplynk.UplynkPingConfiguration
 import com.theoplayer.android.connector.uplynk.UplynkSsaiDescription
@@ -39,6 +40,12 @@ val sources: List<Source> by lazy {
                 "assetid" to "C112233",
                 "program" to "BigBuckBunny with Google IMA ads"
             )
+        ),
+        Source(
+            name = "THEOlive demo",
+            sourceDescription = SourceDescription.Builder(TheoLiveSource(src = "9lwkudxeyjwwm132pukwwhhtk"))
+                .metadata(MetadataDescription(mutableMapOf("title" to "THEOlive demo")))
+                .build()
         ),
         Source(
             name = "Yospace HLS VOD",

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -24,11 +24,13 @@ import com.theoplayer.android.connector.analytics.conviva.theolive.THEOliveRepor
 import com.theoplayer.android.connector.analytics.conviva.utils.ErrorReportBuilder
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateBufferLength
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateConvivaOptions
+import com.theoplayer.android.connector.analytics.conviva.utils.calculateEncodingType
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateStreamType
 import com.theoplayer.android.connector.analytics.conviva.utils.collectPlaybackConfigMetadata
 import com.theoplayer.android.connector.analytics.conviva.utils.collectPlayerInfo
 
 private const val TAG = "ConvivaHandler"
+private const val ENCODING_TYPE = "encoding_type"
 
 interface ConvivaHandlerBase {
     val contentAssetName: String
@@ -475,6 +477,15 @@ class ConvivaHandler(
                 player.duration.takeIf { it.isFinite() }?.let { duration ->
                     // Report duration; Int (seconds)
                     put(ConvivaSdkConstants.DURATION, duration.toInt())
+                }
+
+                // Do not override `encoding_type` value if already set by the customer.
+                // For type HESP, defer until the endpoint has been loaded in THEOliveReporter.
+                val configuredEncodingType =  metadataInfo?.get(ENCODING_TYPE)
+                    ?: metadataInfo?.get(ENCODING_TYPE)
+                val encodingType = configuredEncodingType?: calculateEncodingType(player)
+                encodingType?.let {
+                    put(ENCODING_TYPE, it)
                 }
             }
         )

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -18,7 +18,6 @@ import com.theoplayer.android.api.event.EventListener
 import com.theoplayer.android.api.event.ads.AdEvent
 import com.theoplayer.android.api.event.player.*
 import com.theoplayer.android.api.player.Player
-import com.theoplayer.android.api.source.SourceDescription
 import com.theoplayer.android.connector.analytics.conviva.ads.AdReporter
 import com.theoplayer.android.connector.analytics.conviva.theolive.THEOliveReporter
 import com.theoplayer.android.connector.analytics.conviva.utils.ErrorReportBuilder
@@ -64,7 +63,6 @@ class ConvivaHandler(
 
     private var theoliveReporter: THEOliveReporter? = null
 
-    private var currentSource: SourceDescription? = null
     private var playbackRequested: Boolean = false
 
     private val onPlay: EventListener<PlayEvent>
@@ -180,7 +178,6 @@ class ConvivaHandler(
                 Log.d(TAG, "onSourceChange")
             }
             maybeReportPlaybackEnded()
-            currentSource = player.source
             customMetadata = mapOf("playbackPipeline" to "media3")
         }
 

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ConvivaHandler.kt
@@ -20,6 +20,7 @@ import com.theoplayer.android.api.event.player.*
 import com.theoplayer.android.api.player.Player
 import com.theoplayer.android.api.source.SourceDescription
 import com.theoplayer.android.connector.analytics.conviva.ads.AdReporter
+import com.theoplayer.android.connector.analytics.conviva.theolive.THEOliveReporter
 import com.theoplayer.android.connector.analytics.conviva.utils.ErrorReportBuilder
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateBufferLength
 import com.theoplayer.android.connector.analytics.conviva.utils.calculateConvivaOptions
@@ -55,6 +56,8 @@ class ConvivaHandler(
     private var convivaAdAnalytics: ConvivaAdAnalytics
 
     private var adReporter: AdReporter? = null
+
+    private var theoliveReporter: THEOliveReporter? = null
 
     private var currentSource: SourceDescription? = null
     private var playbackRequested: Boolean = false
@@ -95,6 +98,8 @@ class ConvivaHandler(
             this,
             adEventsExtension,
             )
+
+        theoliveReporter = THEOliveReporter(player, convivaVideoAnalytics)
 
         onPlay = EventListener<PlayEvent> {
             if (BuildConfig.DEBUG) {
@@ -485,6 +490,7 @@ class ConvivaHandler(
         maybeReportPlaybackEnded()
         removeEventListeners()
 
+        theoliveReporter?.destroy()
         adReporter?.destroy()
         customMetadata = mapOf()
         convivaAdAnalytics.release()

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/theolive/THEOliveReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/theolive/THEOliveReporter.kt
@@ -3,6 +3,7 @@ package com.theoplayer.android.connector.analytics.conviva.theolive
 import android.util.Log
 import com.conviva.sdk.ConvivaSdkConstants
 import com.conviva.sdk.ConvivaVideoAnalytics
+import com.theoplayer.android.api.event.EventListener
 import com.theoplayer.android.api.event.player.theolive.EndpointLoadedEvent
 import com.theoplayer.android.api.event.player.theolive.IntentToFallbackEvent
 import com.theoplayer.android.api.event.player.theolive.TheoLiveEventTypes
@@ -14,57 +15,50 @@ import com.theoplayer.android.connector.analytics.conviva.utils.flattenErrorObje
 private const val TAG = "THEOliveReporter"
 
 class THEOliveReporter(val player: Player, val convivaVideoAnalytics: ConvivaVideoAnalytics) {
+
+    private val onEndPointLoaded =
+        EventListener<EndpointLoadedEvent> { handleEndPointLoaded(it) }
+    private val onIntentToFallback =
+        EventListener<IntentToFallbackEvent> { handleIntentToFallback(it) }
+
     init {
         addEventListeners()
     }
 
-    private fun onEndPointLoaded(event: EndpointLoadedEvent) {
+    private fun handleEndPointLoaded(event: EndpointLoadedEvent) {
         val endpoint = event.getEndpoint()
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "onEndPointLoaded - endpoint: $endpoint")
         }
 
-        convivaVideoAnalytics.setContentInfo(
-            mutableMapOf<String, String>().apply {
-                endpoint.cdn?.let { cdn ->
-                    put(ConvivaSdkConstants.DEFAULT_RESOURCE, cdn)
-                }
-            } as ConvivaMetadata
-        )
+        convivaVideoAnalytics.setContentInfo(mutableMapOf<String, String>().apply {
+            endpoint.cdn?.let { cdn ->
+                put(ConvivaSdkConstants.DEFAULT_RESOURCE, cdn)
+            }
+        } as ConvivaMetadata)
     }
 
-    private fun onIntentToFallback(event: IntentToFallbackEvent) {
+    private fun handleIntentToFallback(event: IntentToFallbackEvent) {
         val reason = event.reason
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "IntentToFallbackEvent - reason: ${reason ?: "NA"}")
         }
         convivaVideoAnalytics.reportPlaybackEvent(
-            "intentToFallback",
-            mutableMapOf<String, Any>().apply {
+            "intentToFallback", mutableMapOf<String, Any>().apply {
                 reason?.let {
                     put("reason", flattenErrorObject(reason))
                 }
-            }
-        )
+            })
     }
 
     private fun addEventListeners() {
-        player.theoLive.addEventListener(TheoLiveEventTypes.ENDPOINTLOADED, this::onEndPointLoaded)
-        player.theoLive.addEventListener(
-            TheoLiveEventTypes.INTENTTOFALLBACK,
-            this::onIntentToFallback
-        )
+        player.theoLive.addEventListener(TheoLiveEventTypes.ENDPOINTLOADED, onEndPointLoaded)
+        player.theoLive.addEventListener(TheoLiveEventTypes.INTENTTOFALLBACK, onIntentToFallback)
     }
 
     private fun removeEventListeners() {
-        player.theoLive.removeEventListener(
-            TheoLiveEventTypes.ENDPOINTLOADED,
-            this::onEndPointLoaded
-        )
-        player.theoLive.removeEventListener(
-            TheoLiveEventTypes.INTENTTOFALLBACK,
-            this::onIntentToFallback
-        )
+        player.theoLive.removeEventListener(TheoLiveEventTypes.ENDPOINTLOADED, onEndPointLoaded)
+        player.theoLive.removeEventListener(TheoLiveEventTypes.INTENTTOFALLBACK, onIntentToFallback)
     }
 
     fun destroy() {

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/theolive/THEOliveReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/theolive/THEOliveReporter.kt
@@ -1,0 +1,64 @@
+package com.theoplayer.android.connector.analytics.conviva.theolive
+
+import android.util.Log
+import com.conviva.sdk.ConvivaSdkConstants
+import com.conviva.sdk.ConvivaVideoAnalytics
+import com.theoplayer.android.api.event.player.theolive.EndpointLoadedEvent
+import com.theoplayer.android.api.event.player.theolive.IntentToFallbackEvent
+import com.theoplayer.android.api.event.player.theolive.TheoLiveEventTypes
+import com.theoplayer.android.api.player.Player
+import com.theoplayer.android.connector.analytics.conviva.BuildConfig
+import com.theoplayer.android.connector.analytics.conviva.ConvivaMetadata
+
+private const val TAG = "THEOliveReporter"
+private const val ENCODING_TYPE = "encoding_type"
+
+class THEOliveReporter(val player: Player, val convivaVideoAnalytics: ConvivaVideoAnalytics) {
+    init {
+        addEventListeners()
+    }
+
+    fun destroy() {
+        removeEventListeners()
+    }
+
+    private fun addEventListeners() {
+        player.theoLive.addEventListener(TheoLiveEventTypes.ENDPOINTLOADED, this::onEndPointLoaded)
+        player.theoLive.addEventListener(TheoLiveEventTypes.INTENTTOFALLBACK, this::onIntentToFallback)
+    }
+
+    private fun removeEventListeners() {
+        player.theoLive.removeEventListener(TheoLiveEventTypes.ENDPOINTLOADED, this::onEndPointLoaded)
+        player.theoLive.removeEventListener(TheoLiveEventTypes.INTENTTOFALLBACK, this::onIntentToFallback)
+    }
+
+    private fun onEndPointLoaded(event: EndpointLoadedEvent) {
+        val endpoint = event.getEndpoint()
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "onEndPointLoaded - endpoint: $endpoint")
+        }
+
+        convivaVideoAnalytics.setContentInfo(
+            mutableMapOf<String, String>().apply {
+                // Report CDN
+                endpoint.cdn?.let { cdn ->
+                    put(ConvivaSdkConstants.DEFAULT_RESOURCE, cdn)
+                }
+
+                // Report encoding_type
+                put(ENCODING_TYPE, if (endpoint.hespSrc == null) "HLS" else "HESP")
+            } as ConvivaMetadata
+        )
+    }
+
+    private fun onIntentToFallback(event: IntentToFallbackEvent) {
+        val reason = event.reason ?: "NA"
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "IntentToFallbackEvent - reason: $reason")
+        }
+        convivaVideoAnalytics.reportPlaybackEvent(
+            "intentToFallback",
+            mutableMapOf<String, Any>().apply { put("reason", reason) }
+        )
+    }
+}

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -1,5 +1,6 @@
 package com.theoplayer.android.connector.analytics.conviva.utils
 
+import androidx.core.net.toUri
 import com.conviva.sdk.ConvivaSdkConstants
 import com.conviva.sdk.ConvivaSdkConstants.StreamType
 import com.theoplayer.android.api.THEOplayerGlobal
@@ -87,7 +88,16 @@ fun calculateEncodingType(source: TypedSource?): String? {
         SourceType.DASH -> "DASH"
         SourceType.HLS, SourceType.HLSX -> "HLS"
         SourceType.HESP -> "HESP"
-        else -> null
+        else -> {
+            // No type given, check for known extension.
+            source?.src?.toUri()?.lastPathSegment?.let { pathSegment ->
+                when {
+                    pathSegment.endsWith(".mpd") -> "DASH"
+                    pathSegment.endsWith(".m3u8") -> "HLS"
+                    else -> null
+                }
+            }
+        }
     }
 }
 

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -9,6 +9,7 @@ import com.theoplayer.android.api.ads.LinearAd
 import com.theoplayer.android.api.ads.ima.GoogleImaAd
 import com.theoplayer.android.api.event.ads.AdIntegrationKind
 import com.theoplayer.android.api.player.Player
+import com.theoplayer.android.api.source.SourceType
 import com.theoplayer.android.api.timerange.TimeRanges
 import com.theoplayer.android.connector.analytics.conviva.ConvivaConfiguration
 import com.theoplayer.android.connector.analytics.conviva.ConvivaMetadata
@@ -77,6 +78,16 @@ fun calculateStreamType(player: Player): StreamType? {
         }
     } else {
         null
+    }
+}
+
+fun calculateEncodingType(player: Player): String? {
+    return when (player.source?.sources?.get(0)?.type) {
+        SourceType.DASH -> "DASH"
+        SourceType.HLS, SourceType.HLSX -> "HLS"
+        // for HESP: determine once endpoint has been loaded.
+        // ignore other encodings.
+        else -> null
     }
 }
 

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/utils/Utils.kt
@@ -10,6 +10,7 @@ import com.theoplayer.android.api.ads.ima.GoogleImaAd
 import com.theoplayer.android.api.event.ads.AdIntegrationKind
 import com.theoplayer.android.api.player.Player
 import com.theoplayer.android.api.source.SourceType
+import com.theoplayer.android.api.source.TypedSource
 import com.theoplayer.android.api.timerange.TimeRanges
 import com.theoplayer.android.connector.analytics.conviva.ConvivaConfiguration
 import com.theoplayer.android.connector.analytics.conviva.ConvivaMetadata
@@ -81,12 +82,11 @@ fun calculateStreamType(player: Player): StreamType? {
     }
 }
 
-fun calculateEncodingType(player: Player): String? {
-    return when (player.source?.sources?.get(0)?.type) {
+fun calculateEncodingType(source: TypedSource?): String? {
+    return when (source?.type) {
         SourceType.DASH -> "DASH"
         SourceType.HLS, SourceType.HLSX -> "HLS"
-        // for HESP: determine once endpoint has been loaded.
-        // ignore other encodings.
+        SourceType.HESP -> "HESP"
         else -> null
     }
 }


### PR DESCRIPTION
❗This PR needs the `CurrentSourceChange` events from Android SDK 10.2+

Added:
- reporting of the current source's `encoding_type`, either "DASH", "HLS" or "HESP".
- reporting of THEOlive's `intentToFallback` reason.
- reporting of THEOlive's endpoint cdn through `Conviva.defaultResource`.
- THEOlive demo source.