### PR TITLE
Fix extra preplay parameter when no ping is configured

### DIFF
--- a/connectors/uplynk/src/main/java/com/theoplayer/android/connector/uplynk/internal/UplynkSsaiDescriptionUrlExtensions.kt
+++ b/connectors/uplynk/src/main/java/com/theoplayer/android/connector/uplynk/internal/UplynkSsaiDescriptionUrlExtensions.kt
@@ -28,7 +28,7 @@ internal val UplynkSsaiDescription.pingParameters: String
     get() {
         val feature = UplynkPingFeatures.from(this)
         return if (feature == UplynkPingFeatures.NO_PING) {
-            "&ad.pingc=0"
+            ""
         } else {
             "&ad.pingc=1&ad.pingf=${feature.pingfValue}"
         }

--- a/connectors/uplynk/src/main/java/com/theoplayer/android/connector/uplynk/internal/UplynkSsaiDescriptionUrlExtensions.kt
+++ b/connectors/uplynk/src/main/java/com/theoplayer/android/connector/uplynk/internal/UplynkSsaiDescriptionUrlExtensions.kt
@@ -30,7 +30,7 @@ internal val UplynkSsaiDescription.pingParameters: String
         return if (feature == UplynkPingFeatures.NO_PING) {
             ""
         } else {
-            "&ad.pingc=1&ad.pingf=${feature.pingfValue}"
+            "&ad.cping=1&ad.pingf=${feature.pingfValue}"
         }
     }
 

--- a/connectors/uplynk/src/test/java/com/theoplayer/android/connector/uplynk/internal/UplynkSsaiDescriptionConverterTest.kt
+++ b/connectors/uplynk/src/test/java/com/theoplayer/android/connector/uplynk/internal/UplynkSsaiDescriptionConverterTest.kt
@@ -91,7 +91,7 @@ class UplynkSsaiDescriptionConverterTest {
         assertEquals("preplay", items[1])
         assertEquals("asset1,asset2,asset3", items[2])
         assertEquals("multiple.json", items[3])
-        assertEquals("v=2&ad.pingc=0&p1=v1&p2=v2&p3=v3", items[4])
+        assertEquals("v=2&ad.cping=0&p1=v1&p2=v2&p3=v3", items[4])
     }
 
     @Test

--- a/connectors/uplynk/src/test/java/com/theoplayer/android/connector/uplynk/internal/UplynkSsaiDescriptionConverterTest.kt
+++ b/connectors/uplynk/src/test/java/com/theoplayer/android/connector/uplynk/internal/UplynkSsaiDescriptionConverterTest.kt
@@ -91,7 +91,7 @@ class UplynkSsaiDescriptionConverterTest {
         assertEquals("preplay", items[1])
         assertEquals("asset1,asset2,asset3", items[2])
         assertEquals("multiple.json", items[3])
-        assertEquals("v=2&ad.cping=0&p1=v1&p2=v2&p3=v3", items[4])
+        assertEquals("v=2&p1=v1&p2=v2&p3=v3", items[4])
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue where the player adds a `&ad.pingc=0` to preplay parameters when there is no ping configuration, which causes a 403 since the requested preplay URL no longer matches the signature due to the extra `&ad.pingc=0`. This change aligns the behavior to the Web SDK implementation.

There is also a small correction for the parameter name.