### PR TITLE
Fix `enabledPlaybackActions`

### DIFF
--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionCallback.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionCallback.kt
@@ -12,6 +12,8 @@ import com.theoplayer.android.api.timerange.TimeRanges
 class MediaSessionCallback(private val connector: MediaSessionConnector) :
     MediaSessionCompat.Callback() {
 
+    // region PlaybackPreparer actions
+
     override fun onPrepare() {
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onPrepare")
@@ -48,37 +50,6 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
     }
 
-    override fun onPlay() {
-        if (connector.debug) {
-            Log.d(TAG, "MediaSessionCallback::onPlay")
-        }
-        connector.player?.let { player ->
-            if (shouldHandlePlaybackAction(ACTION_PLAY)) {
-                player.play()
-
-                // Make sure the session is currently active and ready to receive commands.
-                connector.setActive(true)
-            }
-            connector.listeners.forEach { listener ->
-                listener.onPlay()
-            }
-        }
-    }
-
-    override fun onPause() {
-        if (connector.debug) {
-            Log.d(TAG, "MediaSessionCallback::onPause")
-        }
-        connector.player?.let { player ->
-            if (shouldHandlePlaybackAction(ACTION_PAUSE)) {
-                player.pause()
-            }
-            connector.listeners.forEach { listener ->
-                listener.onPause()
-            }
-        }
-    }
-
     override fun onPlayFromMediaId(mediaId: String?, extras: Bundle?) {
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onPlayFromMediaId $mediaId")
@@ -106,13 +77,52 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
     }
 
+    // endregion
+    // region Playback actions
+
+    override fun onPlay() {
+        if (connector.debug) {
+            Log.d(TAG, "MediaSessionCallback::onPlay")
+        }
+        connector.player?.let { player ->
+            if (shouldHandlePlaybackAction(ACTION_PLAY)) {
+                connector.playbackCallback?.onPlay() ?: {
+                    player.play()
+                }
+                // Make sure the session is currently active and ready to receive commands.
+                connector.setActive(true)
+            }
+            connector.listeners.forEach { listener ->
+                listener.onPlay()
+            }
+        }
+    }
+
+    override fun onPause() {
+        if (connector.debug) {
+            Log.d(TAG, "MediaSessionCallback::onPause")
+        }
+        connector.player?.let { player ->
+            if (shouldHandlePlaybackAction(ACTION_PAUSE)) {
+                connector.playbackCallback?.onPause() ?: {
+                    player.pause()
+                }
+            }
+            connector.listeners.forEach { listener ->
+                listener.onPause()
+            }
+        }
+    }
+
     override fun onStop() {
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onStop")
         }
         connector.player?.let { player ->
             if (shouldHandlePlaybackAction(ACTION_STOP)) {
-                player.stop()
+                connector.playbackCallback?.onStop() ?: {
+                    player.stop()
+                }
                 connector.setActive(false)
             }
             connector.listeners.forEach { listener ->
@@ -126,7 +136,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
             Log.d(TAG, "MediaSessionCallback::onFastForward")
         }
         if (shouldHandlePlaybackAction(ACTION_FAST_FORWARD)) {
-            skip(connector.skipForwardInterval)
+            connector.playbackCallback?.onFastForward() ?: {
+                skip(connector.skipForwardInterval)
+            }
         }
         connector.listeners.forEach { listener ->
             listener.onFastForward()
@@ -138,24 +150,12 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
             Log.d(TAG, "MediaSessionCallback::onRewind")
         }
         if (shouldHandlePlaybackAction(ACTION_REWIND)) {
-            skip(-connector.skipBackwardsInterval)
+            connector.playbackCallback?.onRewind() ?: {
+                skip(-connector.skipBackwardsInterval)
+            }
         }
         connector.listeners.forEach { listener ->
             listener.onRewind()
-        }
-    }
-
-    override fun onSetShuffleMode(@ShuffleMode shuffleMode: Int) {
-        // Unsupported.
-        if (connector.debug) {
-            Log.d(TAG, "MediaSessionCallback::onSetShuffleMode $shuffleMode")
-        }
-    }
-
-    override fun onSetRepeatMode(@RepeatMode mediaSessionRepeatMode: Int) {
-        // Unsupported.
-        if (connector.debug) {
-            Log.d(TAG, "MediaSessionCallback::onSetRepeatMode $mediaSessionRepeatMode")
         }
     }
 
@@ -165,13 +165,34 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
         connector.player?.let { player ->
             if (shouldHandlePlaybackAction(ACTION_SET_PLAYBACK_SPEED)) {
-                player.playbackRate = speed.toDouble()
+                connector.playbackCallback?.onSetPlaybackSpeed(speed) ?: {
+                    player.playbackRate = speed.toDouble()
+                }
             }
             connector.listeners.forEach { listener ->
                 listener.onSetPlaybackSpeed(speed)
             }
         }
     }
+
+    override fun onSeekTo(positionMs: Long) {
+        if (connector.debug) {
+            Log.d(TAG, "MediaSessionCallback::onSeekTo $positionMs")
+        }
+        connector.player?.let { player ->
+            if (shouldHandlePlaybackAction(ACTION_SEEK_TO)) {
+                connector.playbackCallback?.onSeekTo(positionMs) ?: {
+                    player.currentTime = 1e-03 * positionMs
+                }
+            }
+            connector.listeners.forEach { listener ->
+                listener.onSeekTo(positionMs)
+            }
+        }
+    }
+
+    // endregion
+    // region QueueNavigator actions
 
     override fun onSkipToNext() {
         if (connector.debug) {
@@ -257,6 +278,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
     }
 
+    // endregion
+    // region Custom actions
+
     override fun onCustomAction(action: String, extras: Bundle?) {
         if (connector.debug) {
             Log.d(TAG, "MediaSessionCallback::onCustomAction $action")
@@ -273,19 +297,8 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
         }
     }
 
-    override fun onSeekTo(positionMs: Long) {
-        if (connector.debug) {
-            Log.d(TAG, "MediaSessionCallback::onSeekTo $positionMs")
-        }
-        connector.player?.let { player ->
-            if (shouldHandlePlaybackAction(ACTION_SEEK_TO)) {
-                player.currentTime = 1e-03 * positionMs
-            }
-            connector.listeners.forEach { listener ->
-                listener.onSeekTo(positionMs)
-            }
-        }
-    }
+    // endregion
+    // region Rating actions
 
     override fun onSetRating(rating: RatingCompat) {
         if (connector.debug) {
@@ -314,6 +327,25 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
             }
         }
     }
+
+    // endregion
+    // region Unsupported actions
+
+    override fun onSetShuffleMode(@ShuffleMode shuffleMode: Int) {
+        // Unsupported.
+        if (connector.debug) {
+            Log.d(TAG, "MediaSessionCallback::onSetShuffleMode $shuffleMode")
+        }
+    }
+
+    override fun onSetRepeatMode(@RepeatMode mediaSessionRepeatMode: Int) {
+        // Unsupported.
+        if (connector.debug) {
+            Log.d(TAG, "MediaSessionCallback::onSetRepeatMode $mediaSessionRepeatMode")
+        }
+    }
+
+    // endregion
 
     private fun skip(skipTime: Double) {
         val player = connector.player ?: return
@@ -349,9 +381,9 @@ class MediaSessionCallback(private val connector: MediaSessionConnector) :
 
     private fun shouldHandleQueueNavigatorAction(action: Long): Boolean {
         return (connector.player != null && (
-                    connector.queueNavigator != null &&
-                    connector.queueNavigator!!.getSupportedQueueNavigatorActions(connector.player!!) and action != 0L ||
-                    connector.shouldDispatchUnsupportedActions)
+                connector.queueNavigator != null &&
+                        connector.queueNavigator!!.getSupportedQueueNavigatorActions(connector.player!!) and action != 0L ||
+                        connector.shouldDispatchUnsupportedActions)
                 )
     }
 

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -96,7 +96,7 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
 
     /**
      * A callback for playback actions. When set, the media session will receive playback events,
-     * otherwise default the behavior will be executed for supported actions.
+     * otherwise the default behavior will be executed for supported actions.
      */
     var playbackCallback: PlaybackCallback? = null
 

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/MediaSessionConnector.kt
@@ -77,9 +77,33 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
             }
         }
 
+    /**
+     * A callback for queue navigation actions. When set, the media session will receive queue
+     * navigation events.
+     */
     var queueNavigator: QueueNavigator? = null
+
+    /**
+     * A callback for rating actions. When set, the media session will receive rating events.
+     */
     var ratingCallback: RatingCallback? = null
+
+    /**
+     * A callback for playback preparation actions.
+     * When set, the media session will receive prepare events.
+     */
     var playbackPreparer: PlaybackPreparer? = null
+
+    /**
+     * A callback for playback actions. When set, the media session will receive playback events,
+     * otherwise default the behavior will be executed for supported actions.
+     */
+    var playbackCallback: PlaybackCallback? = null
+
+    /**
+     * A callback for queue editing actions.
+     * When set, the media session will receive queue editing events.
+     */
     var queueEditor: QueueEditor? = null
         set(value) {
             field = value
@@ -91,6 +115,7 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
             )
         }
 
+
     var shouldDispatchUnsupportedActions: Boolean = false
 
     /**
@@ -99,7 +124,13 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
     var shouldDispatchTimeUpdateEvents: Boolean = false
 
     var debug: Boolean = BuildConfig.DEBUG
+
+    /**
+     * The playback actions that are enabled for the media session.
+     * By default, all actions supported by the player are enabled.
+     */
     var enabledPlaybackActions: Long = PlaybackStateProvider.DEFAULT_PLAYBACK_ACTIONS
+
     var customActionProviders: Array<CustomActionProvider> = arrayOf()
 
     /**
@@ -201,4 +232,4 @@ class MediaSessionConnector(val mediaSession: MediaSessionCompat) {
             Log.d(TAG, "MediaSession released")
         }
     }
- }
+}

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackCallback.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackCallback.kt
@@ -1,0 +1,44 @@
+package com.theoplayer.android.connector.mediasession
+
+/**
+ * PlaybackCallback allows handling playback actions when sent by a media controller.
+ * By default, the connector will execute default behavior for supported actions.
+ * Setting a PlaybackCallback will disable the default handling of these actions, and instead route
+ * them to the callback.
+ */
+interface PlaybackCallback {
+    /**
+     * Called when a media controller wants to play or pause the current media.
+     */
+    fun onPlay()
+
+    /**
+     * Called when a media controller wants to pause the current media.
+     */
+    fun onPause()
+
+    /**
+     * Called when a media controller wants to stop the current media.
+     */
+    fun onStop()
+
+    /**
+     * Called when a media controller wants to fast forward the current media.
+     */
+    fun onFastForward()
+
+    /**
+     * Called when a media controller wants to rewind the current media.
+     */
+    fun onRewind()
+
+    /**
+     * Called when a media controller wants to change the playback speed of the current media.
+     */
+    fun onSetPlaybackSpeed(speed: Float)
+
+    /**
+     * Called when a media controller wants to seek to a specific position in the current media.
+     */
+    fun onSeekTo(positionMs: Long)
+}

--- a/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
+++ b/connectors/mediasession/src/main/java/com/theoplayer/android/connector/mediasession/PlaybackStateProvider.kt
@@ -139,7 +139,7 @@ class PlaybackStateProvider(private val connector: MediaSessionConnector) {
     }
 
     private fun buildPlaybackActions(): Long {
-        var playbackActions = DEFAULT_PLAYBACK_ACTIONS
+        var playbackActions = connector.enabledPlaybackActions
 
         // Optionally add queueNavigator actions.
         val queueNavigator = connector.queueNavigator


### PR DESCRIPTION
- Fixed an issue where changing the set of `enabledPlaybackActions` would not be passed correctly to the MediaSession's `PlaybackState` builder.
- Added an optional `PlaybackCallback` instance that allows intercepting and overwriting behavior for playback actions triggered by MediaSession.