### PR TITLE
Fix ad bitrate reporting for Conviva

### DIFF
--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
@@ -205,11 +205,11 @@ class AdReporter(
         player.removeEventListener(PlayerEventTypes.PAUSE, onPause)
 
         (listOf(player.ads, adEventsExtension)).forEach { ads ->
-            ads?.addEventListener(AdsEventTypes.AD_BEGIN, onAdBegin)
-            ads?.addEventListener(AdsEventTypes.AD_END, onAdEnd)
-            ads?.addEventListener(AdsEventTypes.AD_BREAK_END, onAdBreakEnd)
-            ads?.addEventListener(AdsEventTypes.AD_SKIP, onAdSkip)
-            ads?.addEventListener(AdsEventTypes.AD_ERROR, onAdError)
+            ads?.removeEventListener(AdsEventTypes.AD_BEGIN, onAdBegin)
+            ads?.removeEventListener(AdsEventTypes.AD_END, onAdEnd)
+            ads?.removeEventListener(AdsEventTypes.AD_BREAK_END, onAdBreakEnd)
+            ads?.removeEventListener(AdsEventTypes.AD_SKIP, onAdSkip)
+            ads?.removeEventListener(AdsEventTypes.AD_ERROR, onAdError)
 
             ads?.removeEventListener(GoogleImaAdEventType.STARTED, onImaAdStarted)
             ads?.removeEventListener(GoogleImaAdEventType.COMPLETED, onImaAdCompleted)

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
@@ -286,7 +286,6 @@ class AdReporter(
             if (ad is GoogleImaAd) {
                 convivaAdAnalytics.reportAdMetric(
                     ConvivaSdkConstants.PLAYBACK.BITRATE,
-                    player.videoWidth,
                     ad.imaAd.vastMediaBitrate
                 )
             } else {

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
@@ -305,7 +305,7 @@ class AdReporter(
             }
         } else {
             if (BuildConfig.DEBUG) {
-                Log.w(TAG, "handleAdEnd - No valid ad")
+                Log.w(TAG, "handleAdBegin - No valid ad")
             }
         }
     }

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
@@ -283,17 +283,10 @@ class AdReporter(
                 player.videoWidth,
                 player.videoHeight
             )
-            if (ad is GoogleImaAd) {
-                convivaAdAnalytics.reportAdMetric(
-                    ConvivaSdkConstants.PLAYBACK.BITRATE,
-                    ad.imaAd.vastMediaBitrate
-                )
-            } else {
-                convivaAdAnalytics.reportAdMetric(
-                    ConvivaSdkConstants.PLAYBACK.BITRATE,
-                    player.videoWidth
-                )
-            }
+            convivaAdAnalytics.reportAdMetric(
+                ConvivaSdkConstants.PLAYBACK.BITRATE,
+                if (ad is GoogleImaAd) ad.imaAd.vastMediaBitrate else 0
+            )
 
             // Report playing state in case of SSAI, as the player will not send an additional
             // `playing` event.

--- a/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
+++ b/connectors/analytics/conviva/src/main/java/com/theoplayer/android/connector/analytics/conviva/ads/AdReporter.kt
@@ -330,7 +330,6 @@ class AdReporter(
                 Log.d(TAG, "reportAdBreakEnded")
             }
             convivaVideoAnalytics.reportAdBreakEnded()
-            currentAdBreak = null
         } else {
             if (BuildConfig.DEBUG) {
                 Log.w(TAG, "handleAdBreakEnd - No current adBreak")


### PR DESCRIPTION
This PR fixes ad bitrate reporting for Conviva connector.

It seems passing `player.videoWidth` in there causes an issue with the reporting. Removing it fixes the issue as it is not necessary ([we don't pass it there on Web either](https://github.com/THEOplayer/web-connectors/blob/db4a876f7a43f8e44663ecb9ee146588891f62b6/conviva/src/integration/ads/AdReporter.ts#L201-L204)).