### PR TITLE
Don't tag when updating player version

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -48,12 +48,11 @@ jobs:
         run: ./gradlew :updateVersion -PsdkVersion=$VERSION
         env:
           VERSION: ${{ inputs.version }}
-      - name: Commit and tag
+      - name: Commit
         # language=bash
         run: |
           git add .
-          git commit -m "New release $VERSION"
-          git tag "$VERSION"
+          git commit -m "Update player to version $VERSION"
         env:
           VERSION: ${{ inputs.version }}
       - name: Push to origin
@@ -61,7 +60,6 @@ jobs:
         # language=bash
         run: |
           git push origin
-          git push origin tag "$VERSION"
         env:
           VERSION: ${{ inputs.version }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,5 +1,5 @@
-name: Update version
-run-name: ${{ format('Update version to {0}', inputs.version) }}${{ inputs.dryRun == true && ' (dry run)' || '' }}
+name: Update player version
+run-name: ${{ format('Update player version to {0}', inputs.version) }}${{ inputs.dryRun == true && ' (dry run)' || '' }}
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -44,7 +44,7 @@ jobs:
         with:
           # https://github.com/gradle/actions/blob/v6.0.0/README.md#licensing-notice
           cache-disabled: true
-      - name: Update version
+      - name: Update player version
         run: ./gradlew :updateVersion -PsdkVersion=$VERSION
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
As announced in https://github.com/THEOplayer/android-connector/pull/78, we will no longer automatically release a new version of the Android connectors whenever we release a new version of the Android SDK. This PR puts that into effect.

When a new version of the Android SDK is released, we will still push a commit that updates the SDK version inside this repository. However, this will only bump the *preferred* SDK version, and it will *not* immediately trigger a connector release. This will also trigger our CI, so *if* there are any compatibility problems with the new SDK release, we can fix those and decide to make a connector release anyway.