### PR TITLE
Rework release CI

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,58 @@
+name: Create release PR
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version'
+        required: true
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Create app token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
+          private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Configure Git user
+        run: |
+          git config user.name 'theoplayer-bot[bot]'
+          git config user.email '873105+theoplayer-bot[bot]@users.noreply.github.com'
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          # https://github.com/gradle/actions/blob/v6.0.0/README.md#licensing-notice
+          cache-disabled: true
+      - name: Update connector version
+        run: ./gradlew :updateVersion -PconnectorVersion=$VERSION
+        env:
+          VERSION: ${{ inputs.version }}
+      - name: Push to release branch
+        shell: bash
+        run: |
+          git commit -a -m ${{ inputs.version }}
+          git push origin "HEAD:release/${{ inputs.version }}"
+      - name: Create pull request
+        shell: bash
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/${{ inputs.version }}" \
+            --title "Release ${{ inputs.version }}" \
+            --body "This will release a new version of the Android connectors."
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,22 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
+      - name: Create app token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
+          private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Configure Git user
+        run: |
+          git config user.name 'theoplayer-bot[bot]'
+          git config user.email '873105+theoplayer-bot[bot]@users.noreply.github.com'
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -50,4 +63,12 @@ jobs:
           git tag "$VERSION" -m "New release $VERSION"
           git push origin tag "$VERSION"
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.get-version.version }}
+      - name: Create GitHub release
+        run: |
+          gh release create "$VERSION" --verify-tag --latest \
+            --title "$VERSION"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.get-version.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,22 @@
 name: Publish release
 on:
-  # Runs whenever a new tag is pushed
-  push:
-    tags:
-      - '*.*.*'
+  # Runs whenever a release PR is merged
+  pull_request:
+    branches:
+      - main
+    types: [ closed ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   # Publish job
   publish:
+    # Run only for "release/x.y.z" PRs, and only when the PR is merged (not abandoned)
+    if: ${{ !github.event.pull_request || (startsWith(github.head_ref, 'release/') && github.event.pull_request.merged) }}
     runs-on: ubuntu-latest
     # Sets permissions of the GITHUB_TOKEN to allow publishing to GitHub Packages
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout
@@ -28,6 +31,12 @@ jobs:
         with:
           # https://github.com/gradle/actions/blob/v6.0.0/README.md#licensing-notice
           cache-disabled: true
+      - name: Get version
+        id: get-version
+        shell: bash
+        run: |
+          version=$(./gradlew :getVersion --console=plain --quiet)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Publish package
         run: ./gradlew publish
         env:
@@ -36,3 +45,9 @@ jobs:
           REPOSILITE_PASSWORD: ${{ secrets.REPOSILITE_PASSWORD }}
           YOSPACE_USERNAME: ${{ secrets.YOSPACE_USERNAME }}
           YOSPACE_PASSWORD: ${{ secrets.YOSPACE_PASSWORD }}
+      - name: Push tag
+        run: |
+          git tag "$VERSION" -m "New release $VERSION"
+          git push origin tag "$VERSION"
+        env:
+          VERSION: ${{ steps.get-version.version }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -45,7 +45,7 @@ jobs:
           # https://github.com/gradle/actions/blob/v6.0.0/README.md#licensing-notice
           cache-disabled: true
       - name: Update player version
-        run: ./gradlew :updateVersion -PsdkVersion=$VERSION
+        run: ./gradlew :updatePlayerVersion -PsdkVersion=$VERSION
         env:
           VERSION: ${{ inputs.version }}
       - name: Commit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,12 @@ plugins {
     alias(libs.plugins.kotlinx.serialization) apply false
 }
 
+tasks.register("getVersion") {
+    doLast {
+        println(rootProject.version)
+    }
+}
+
 tasks.register("updateVersion") {
     val versionCatalog = rootProject.file("gradle/libs.versions.toml")
     inputs.file(versionCatalog)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,23 @@ tasks.register("updateVersion") {
     val versionCatalog = rootProject.file("gradle/libs.versions.toml")
     inputs.file(versionCatalog)
 
+    val connectorVersion: String? by project.ext
+    require(!connectorVersion.isNullOrBlank()) { "Missing connectorVersion" }
+
+    ant.withGroovyBuilder {
+        "replaceregexp"(
+            "file" to versionCatalog,
+            "match" to """^androidConnector = ".+"$""",
+            "replace" to """androidConnector = "$connectorVersion"""",
+            "byline" to true
+        )
+    }
+}
+
+tasks.register("updatePlayerVersion") {
+    val versionCatalog = rootProject.file("gradle/libs.versions.toml")
+    inputs.file(versionCatalog)
+
     val sdkVersion: String? by project.ext
     require(!sdkVersion.isNullOrBlank()) { "Missing sdkVersion" }
 
@@ -32,12 +49,6 @@ tasks.register("updateVersion") {
             "file" to versionCatalog,
             "match" to """^theoplayer = \{(.*) prefer = ".+" (.*)\}$""",
             "replace" to """theoplayer = {\1 prefer = "$sdkVersion" \2}""",
-            "byline" to true
-        )
-        "replaceregexp"(
-            "file" to versionCatalog,
-            "match" to """^androidConnector = ".+"$""",
-            "replace" to """androidConnector = "$sdkVersion"""",
             "byline" to true
         )
     }


### PR DESCRIPTION
This reworks the release workflow:
1. Run the new "Create release PR" workflow to bump the connector version and open a PR.
2. When the release PR is approved and merged, publish the release to Maven.

Based on https://github.com/THEOplayer/android-ui/pull/38