### PR TITLE
Bump Yospace library

### DIFF
--- a/app/src/main/java/com/theoplayer/android/connector/Sources.kt
+++ b/app/src/main/java/com/theoplayer/android/connector/Sources.kt
@@ -86,7 +86,7 @@ val sources: List<Source> by lazy {
             sourceDescription = SourceDescription
                 .Builder(
                     TypedSource.Builder(
-                        "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yospace02,hlssample42.m3u8?yo.br=true&yo.av=4"
+                        "https://csm-e-sdk-validation-eb.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.av=5"
                     )
                         .type(SourceType.HLS)
                         .ssai(YospaceSsaiDescription(streamType = YospaceStreamType.LIVE))
@@ -99,7 +99,7 @@ val sources: List<Source> by lazy {
             sourceDescription = SourceDescription
                 .Builder(
                     TypedSource.Builder(
-                        "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yospace02,hlssample42.m3u8?yo.br=true&yo.lp=true&yo.av=4"
+                        "https://csm-e-sdk-validation-eb.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=5&yo.lpa=dur"
                     )
                         .type(SourceType.HLS)
                         .ssai(YospaceSsaiDescription(streamType = YospaceStreamType.LIVEPAUSE))
@@ -125,7 +125,7 @@ val sources: List<Source> by lazy {
             sourceDescription = SourceDescription
                 .Builder(
                     TypedSource.Builder(
-                        "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk01,dash.mpd?yo.br=true&yo.lp=true&yo.jt=1000&yo.av=4"
+                        "https://csm-e-sdk-validation-eb.bln1.yospace.com/csm/extlive/yosdk02,dash-mp4-pre.mpd?yo.br=false&yo.av=5&yo.lpa=dur"
                     )
                         .type(SourceType.DASH)
                         .ssai(YospaceSsaiDescription(streamType = YospaceStreamType.LIVEPAUSE))

--- a/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/AdHandler.kt
+++ b/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/AdHandler.kt
@@ -62,13 +62,14 @@ internal class AdHandler(
     }
 
     private fun getAdInit(advert: YospaceAdvert): AdInit {
-        val nonLinearCreative = if (advert.isNonLinear) advert.getNonLinearCreatives(Resource.ResourceType.STATIC).firstOrNull() else null
+        val isNonLinear = advert.linearCreative == null
+        val nonLinearCreative = if (isNonLinear) advert.getNonLinearCreatives(Resource.ResourceType.STATIC).firstOrNull() else null
         return AdInit(
-            type = if (advert.isNonLinear) "nonlinear" else "linear",
+            type = if (isNonLinear) "nonlinear" else "linear",
             skipOffset = if (advert.skipOffset < 0) -1 else (advert.skipOffset / 1000).toInt(),
             id = advert.identifier,
             duration = (advert.duration / 1000).toInt(),
-            clickThrough = if (advert.isNonLinear) nonLinearCreative?.clickThroughUrl else advert.linearCreative?.clickThroughUrl,
+            clickThrough = if (isNonLinear) nonLinearCreative?.clickThroughUrl else advert.linearCreative?.clickThroughUrl,
             resourceURI = nonLinearCreative?.getResource(Resource.ResourceType.STATIC)?.stringData
         )
     }

--- a/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/SessionPropertiesUtil.kt
+++ b/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/SessionPropertiesUtil.kt
@@ -19,7 +19,7 @@ internal fun Session.SessionProperties.copy(
     fireHistoricalBeacons: Boolean = this.fireHistoricalBeacons,
     applyEncryptedTracking: Boolean = this.applyEncryptedTracking,
     excludedCategories: Int = this.excludedCategories,
-    consecutiveBreakTolerance: Int = this.consecutiveBreakTolerance,
+    alignConsecutiveBreaks: Boolean = this.alignConsecutiveBreaks,
     token: UUID = this.token,
     customHttpHeaders: Map<String, String> = this.customHttpHeaders,
 ) = Session.SessionProperties().apply {
@@ -32,7 +32,7 @@ internal fun Session.SessionProperties.copy(
     this.fireHistoricalBeacons = fireHistoricalBeacons
     this.applyEncryptedTracking = applyEncryptedTracking
     this.excludeFromSuppression(excludedCategories)
-    this.consecutiveBreakTolerance = consecutiveBreakTolerance
+    this.alignConsecutiveBreaks = alignConsecutiveBreaks
     this.token = token
     this.customHttpHeaders = customHttpHeaders
 }
@@ -48,7 +48,7 @@ internal data class SerializedSessionProperties(
     val fireHistoricalBeacons: Boolean,
     val applyEncryptedTracking: Boolean,
     val excludedCategories: Int,
-    val consecutiveBreakTolerance: Int,
+    val alignConsecutiveBreaks: Boolean,
     val token: String,
     val customHttpHeaders: Map<String, String>,
 )
@@ -63,7 +63,7 @@ internal fun Session.SessionProperties.serialize() = SerializedSessionProperties
     fireHistoricalBeacons = fireHistoricalBeacons,
     applyEncryptedTracking = applyEncryptedTracking,
     excludedCategories = excludedCategories,
-    consecutiveBreakTolerance = consecutiveBreakTolerance,
+    alignConsecutiveBreaks = alignConsecutiveBreaks,
     token = token.toString(),
     customHttpHeaders = customHttpHeaders,
 )
@@ -80,7 +80,7 @@ internal fun SerializedSessionProperties.deserialize(): Session.SessionPropertie
         fireHistoricalBeacons = serialized.fireHistoricalBeacons
         applyEncryptedTracking = serialized.applyEncryptedTracking
         excludeFromSuppression(serialized.excludedCategories)
-        consecutiveBreakTolerance = serialized.consecutiveBreakTolerance
+        alignConsecutiveBreaks = serialized.alignConsecutiveBreaks
         token = UUID.fromString(serialized.token)
         customHttpHeaders = serialized.customHttpHeaders
     }

--- a/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/YospaceAdIntegration.kt
+++ b/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/YospaceAdIntegration.kt
@@ -87,7 +87,7 @@ internal class YospaceAdIntegration(
             Session.SessionState.NO_ANALYTICS -> {
                 sourceWithYospace = source
                 // Set up
-                setupSession(session, isLive = ssaiDescription.streamType == YospaceStreamType.LIVE)
+                setupSession(session)
                 // Notify listener
                 listener.onSessionAvailable()
                 // Replace source with playback URL
@@ -116,7 +116,8 @@ internal class YospaceAdIntegration(
         return source
     }
 
-    private fun setupSession(session: Session, isLive: Boolean) {
+    private fun setupSession(session: Session) {
+        val isLive = session.sessionMode == Session.SessionMode.LIVE
         this.session = session
         if (isLive) {
             // Timed metadata is only used for live playback

--- a/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/YospaceAdIntegration.kt
+++ b/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/YospaceAdIntegration.kt
@@ -186,9 +186,9 @@ internal class YospaceAdIntegration(
     }
 
     private fun removeStreamStartListeners() {
-        player.addEventListener(PlayerEventTypes.LOADEDMETADATA, onSeekableChange)
-        player.addEventListener(PlayerEventTypes.DURATIONCHANGE, onSeekableChange)
-        player.addEventListener(PlayerEventTypes.TIMEUPDATE, onSeekableChange)
+        player.removeEventListener(PlayerEventTypes.LOADEDMETADATA, onSeekableChange)
+        player.removeEventListener(PlayerEventTypes.DURATIONCHANGE, onSeekableChange)
+        player.removeEventListener(PlayerEventTypes.TIMEUPDATE, onSeekableChange)
     }
 
     private val onVolumeChange = EventListener<VolumeChangeEvent> {

--- a/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/YospaceAdIntegration.kt
+++ b/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/YospaceAdIntegration.kt
@@ -87,7 +87,7 @@ internal class YospaceAdIntegration(
             Session.SessionState.NO_ANALYTICS -> {
                 sourceWithYospace = source
                 // Set up
-                setupSession(session)
+                setupSession(session, isLive = ssaiDescription.streamType == YospaceStreamType.LIVE)
                 // Notify listener
                 listener.onSessionAvailable()
                 // Replace source with playback URL
@@ -116,8 +116,7 @@ internal class YospaceAdIntegration(
         return source
     }
 
-    private fun setupSession(session: Session) {
-        val isLive = session.playbackMode == Session.PlaybackMode.LIVE
+    private fun setupSession(session: Session, isLive: Boolean) {
         this.session = session
         if (isLive) {
             // Timed metadata is only used for live playback

--- a/connectors/yospace/src/test/java/com/theoplayer/android/connector/yospace/internal/YospaceSsaiDescriptionSerializerTests.kt
+++ b/connectors/yospace/src/test/java/com/theoplayer/android/connector/yospace/internal/YospaceSsaiDescriptionSerializerTests.kt
@@ -32,7 +32,7 @@ class YospaceSsaiDescriptionSerializerTests {
                 "fireHistoricalBeacons",
                 "applyEncryptedTracking",
                 "excludedCategories",
-                "consecutiveBreakTolerance",
+                "alignConsecutiveBreaks",
                 "token",
                 "customHttpHeaders"
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ robolectric = "4.16.1"
 conviva = "4.0.43"
 nielsen = "9.2.0.0"
 comscore = "6.10.0"
-yospace = { strictly = "[3.11.0, 4.0)", prefer = "3.11.2" }
+yospace = { strictly = "[3.10.0, 4.0)", prefer = "3.11.2" }
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ robolectric = "4.16.1"
 conviva = "4.0.43"
 nielsen = "9.2.0.0"
 comscore = "6.10.0"
-yospace = { strictly = "[3.6, 4.0)", prefer = "3.6.7" }
+yospace = { strictly = "[3.11.0, 4.0)", prefer = "3.11.2" }
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }


### PR DESCRIPTION
This PR bumps the Yospace library from 3.6.7 to 3.11.2.

Yospace doesn't seem to follow semver, and seem to have [deprecated some APIs on 3.10.X and removed them on 3.11.X](https://docs.yospace.com/library/technical/sdk-api/ad-management/android/latest/release_notes.html). Since our connector is compatible up to 4.X, we needed to make some changes. Mainly:

- Reworked removed `session.getPlaybackMode()` and `advert.isNonLinear()`.
- Replaced removed `consecutiveBreakTolerance` with `alignConsecutiveBreaks`.